### PR TITLE
Add steering project seeding script

### DIFF
--- a/scripts/projects/openg7-steering-wave1.json
+++ b/scripts/projects/openg7-steering-wave1.json
@@ -1,0 +1,178 @@
+[
+  {
+    "title": "Publish OpenG7 mission & vision on homepage",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular) + CMS (Strapi)",
+    "difficulty": "Easy",
+    "repos": ["openg7-org", "strapi"],
+    "agents_id": null,
+    "labels": ["help wanted", "content", "i18n"],
+    "body_en": "Use the official OpenG7 mission and vision text from the README to populate the homepage hero/content in Strapi and render it on the Angular frontend (FR/EN). Keep copy close to the current README and prepare for future updates via CMS.",
+    "body_fr": "Utiliser le texte officiel de mission et de vision OpenG7 (README) pour alimenter la page d’accueil dans Strapi et l’afficher dans le frontend Angular (FR/EN). Garder le contenu proche du README actuel et prêt pour de futures mises à jour via le CMS."
+  },
+  {
+    "title": "Implement hero section with CTAs (AG-1.2)",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org"],
+    "agents_id": "AG-1.2",
+    "labels": ["map", "hero", "good first issue"],
+    "body_en": "Implement the standalone hero components (hero layout, copy, primary/secondary CTAs) using the official [data-og7] selectors and i18n texts. Wire CTAs to placeholder routes (e.g. /map, /companies) until final flows are defined.",
+    "body_fr": "Implémenter les composants hero standalone (layout, texte, CTA principal/secondaire) en utilisant les sélecteurs [data-og7] officiels et les textes i18n. Relier les CTAs à des routes temporaires (ex. /map, /companies) en attendant les parcours finaux."
+  },
+  {
+    "title": "Implement trade map frame + controls (AG-1.3)",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Hard",
+    "repos": ["openg7-org"],
+    "agents_id": "AG-1.3",
+    "labels": ["map", "leaflet", "a11y"],
+    "body_en": "Implement the TradeMap component with its frame and controls: zoom, base layer toggle, legend, KPI badges and sector chips. Use Leaflet integration and respect performance/a11y constraints (keyboard navigation, focus states).",
+    "body_fr": "Implémenter le composant TradeMap avec son cadre et ses contrôles : zoom, changement de fond de carte, légende, badges KPI et puces de secteurs. Utiliser l’intégration Leaflet et respecter les contraintes de performance et d’accessibilité (navigation clavier, états de focus)."
+  },
+  {
+    "title": "Company table & drawer (AG-1.4)",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org"],
+    "agents_id": "AG-1.4",
+    "labels": ["mat-table", "good first issue"],
+    "body_en": "Create the company listing table (Mat-Table) and the right-side detail drawer, driven by typed data models. Start with mock data or simple API responses and prepare inputs/outputs for future Strapi integration.",
+    "body_fr": "Créer le tableau des entreprises (Mat-Table) et le panneau de détails latéral, basés sur des modèles de données typés. Commencer avec des données mock ou une API simple et préparer les entrées/sorties pour la future intégration avec Strapi."
+  },
+  {
+    "title": "Auth prototype: login/register/profile (AG-1.5)",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org"],
+    "agents_id": "AG-1.5",
+    "labels": ["auth", "prototype"],
+    "body_en": "Implement basic login, register, profile and access-denied pages using typed reactive forms and [data-og7] selectors. This is a prototype flow: focus on UX, structure and i18n rather than production security.",
+    "body_fr": "Implémenter les pages de base login, inscription, profil et accès refusé en utilisant des formulaires réactifs typés et les sélecteurs [data-og7]. Il s’agit d’un flux prototype : privilégier l’UX, la structure et l’i18n plutôt que la sécurité de production."
+  },
+  {
+    "title": "Seed provinces, sectors, companies, exchanges (AG-5)",
+    "project_status": "Backlog validated",
+    "track": "CMS (Strapi)",
+    "difficulty": "Medium",
+    "repos": ["strapi"],
+    "agents_id": "AG-5",
+    "labels": ["seed", "data", "help wanted"],
+    "body_en": "Create idempotent Strapi seeds for provinces, sectors, demo companies and economic exchanges so the map and directory can display realistic data. Seeds should be re-runnable without creating duplicates.",
+    "body_fr": "Créer des seeds Strapi idempotents pour les provinces, secteurs, entreprises de démonstration et échanges économiques afin que la carte et le bottin affichent des données réalistes. Les seeds doivent être relançables sans créer de doublons."
+  },
+  {
+    "title": "Document local dev quickstart (front + CMS)",
+    "project_status": "Backlog validated",
+    "track": "Docs",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["docs", "good first issue"],
+    "body_en": "Write a concise \"Getting started (dev)\" guide explaining how to run the CMS and web front: yarn dev:cms, yarn dev:web, yarn dev:all, expected ports and basic troubleshooting.",
+    "body_fr": "Rédiger un guide concis « Getting started (dev) » expliquant comment lancer le CMS et le frontend : yarn dev:cms, yarn dev:web, yarn dev:all, ports attendus et dépannage de base."
+  },
+  {
+    "title": "Explain AGENTS.md for new contributors",
+    "project_status": "Backlog validated",
+    "track": "Docs",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["docs", "good first issue"],
+    "body_en": "Add documentation that explains what AGENTS.md is, how AG-X.Y IDs map to real components and tasks, and how contributors should reference them in issues and PR titles/descriptions.",
+    "body_fr": "Ajouter une documentation qui explique ce qu’est AGENTS.md, comment les identifiants AG-X.Y correspondent à des composants et tâches réelles, et comment les contributeurs doivent les référencer dans les issues et PR."
+  },
+  {
+    "title": "Set up CI step for selector validation (AG-12)",
+    "project_status": "Backlog validated",
+    "track": "Tooling / CI",
+    "difficulty": "Medium",
+    "repos": [".github", "packages/tooling"],
+    "agents_id": "AG-12",
+    "labels": ["ci", "selectors"],
+    "body_en": "Add a GitHub Actions workflow job that runs the selector validation script (validate-selectors) to ensure every [data-og7] hook declared in AGENTS.md actually exists in the Angular templates.",
+    "body_fr": "Ajouter un job GitHub Actions qui exécute le script de validation des sélecteurs (validate-selectors) pour s’assurer que chaque hook [data-og7] déclaré dans AGENTS.md existe réellement dans les templates Angular."
+  },
+  {
+    "title": "Set up CI step for API validation",
+    "project_status": "Backlog validated",
+    "track": "Tooling / CI",
+    "difficulty": "Medium",
+    "repos": [".github", "packages/tooling"],
+    "agents_id": null,
+    "labels": ["ci", "api"],
+    "body_en": "Add a CI job that runs the API validation script (validate-api) against Strapi dev/preprod environments and fails if critical endpoints used by the frontend are broken.",
+    "body_fr": "Ajouter un job CI qui exécute le script de validation d’API (validate-api) sur les environnements Strapi dev/préprod et échoue si des endpoints critiques utilisés par le frontend sont cassés."
+  },
+  {
+    "title": "Improve CONTRIBUTING.md with Project instructions",
+    "project_status": "Backlog validated",
+    "track": "Docs + Community",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["docs", "community", "good first issue"],
+    "body_en": "Update CONTRIBUTING.md to explain how to use the \"@OpenG7 – Steering & Delivery\" Project: how to pick a card, move it between columns, and link PRs to Project items.",
+    "body_fr": "Mettre à jour CONTRIBUTING.md pour expliquer comment utiliser le Project « @OpenG7 – Pilotage & Livraison » : comment choisir une carte, la déplacer entre les colonnes et lier les PR aux items du Project."
+  },
+  {
+    "title": "Create GitHub issue templates (bugs/feature/docs)",
+    "project_status": "Backlog validated",
+    "track": "Docs + Community",
+    "difficulty": "Easy",
+    "repos": [".github"],
+    "agents_id": null,
+    "labels": ["templates", "good first issue"],
+    "body_en": "Add GitHub issue templates for bug reports, feature requests and documentation tasks to standardise community contributions and speed up triage.",
+    "body_fr": "Ajouter des modèles d’issues GitHub pour les rapports de bug, les demandes de fonctionnalités et les tâches de documentation afin de standardiser les contributions et d’accélérer le triage."
+  },
+  {
+    "title": "First \"Humanitarian Aid 2.0\" concept doc",
+    "project_status": "Cadrage & Strategic ideas",
+    "track": "Docs + Community",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["humanitarian-2.0", "strategy"],
+    "body_en": "Draft a short concept note describing how citizen humanitarian signals (reports, needs) could appear in the UI and data model of OpenG7. No code yet: focus on scenarios, data fields and ethics.",
+    "body_fr": "Rédiger une courte note de concept décrivant comment les signaux humanitaires citoyens (signalements, besoins) pourraient apparaître dans l’UI et le modèle de données d’OpenG7. Aucun code pour l’instant : se concentrer sur les scénarios, champs de données et enjeux éthiques."
+  },
+  {
+    "title": "Map performance & a11y checklist",
+    "project_status": "Design & Multi-repo breakdown",
+    "track": "Front (Angular)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["map", "a11y", "perf"],
+    "body_en": "Create a repeatable checklist for map-related PRs: LCP and FPS targets, keyboard navigation, focus management, reduced motion, colour contrast for layers and badges. Store it in docs and reference it in AGENTS.",
+    "body_fr": "Créer une checklist réutilisable pour les PR liées à la carte : objectifs de LCP et FPS, navigation clavier, gestion du focus, réduction des animations, contraste des couches et badges. La stocker dans la documentation et la référencer dans AGENTS."
+  },
+  {
+    "title": "Contracts package – minimal OpenAPI snapshot",
+    "project_status": "Backlog validated",
+    "track": "Contracts",
+    "difficulty": "Medium",
+    "repos": ["packages/contracts"],
+    "agents_id": null,
+    "labels": ["openapi", "typescript", "contracts"],
+    "body_en": "Export an initial OpenAPI spec from Strapi and wire it into @openg7/contracts so the Angular app can consume typed responses for key entities (Province, Sector, Company, Exchange).",
+    "body_fr": "Exporter une première spécification OpenAPI depuis Strapi et l’intégrer dans @openg7/contracts afin que l’app Angular consomme des réponses typées pour les entités clés (Province, Secteur, Entreprise, Échange)."
+  },
+  {
+    "title": "Document \"local validation chain\" for PR authors",
+    "project_status": "Backlog validated",
+    "track": "Docs",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["docs", "ci"],
+    "body_en": "Turn the local validation chain (yarn lint, yarn format:check, yarn validate:selectors, yarn codegen && yarn test, yarn predeploy:cms-cache, yarn prebuild:web) into a friendly \"Before you open a PR\" checklist.",
+    "body_fr": "Transformer la chaîne de validation locale (yarn lint, yarn format:check, yarn validate:selectors, yarn codegen && yarn test, yarn predeploy:cms-cache, yarn prebuild:web) en une checklist « Avant d’ouvrir une PR » facile à suivre."
+  }
+]

--- a/scripts/projects/openg7-steering-wave2.json
+++ b/scripts/projects/openg7-steering-wave2.json
@@ -1,0 +1,167 @@
+[
+  {
+    "title": "Implement global search box (omnibox)",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["search", "ux", "good first issue"],
+    "body_en": "Implement the global search box [data-og7=\"search-box\"] and wire it to a simple search service (mock or Strapi) that can query companies, sectors and provinces. Ensure keyboard accessibility, debounced input and i18n placeholders for EN/FR.",
+    "body_fr": "Implémenter le champ de recherche global [data-og7=\"search-box\"] et le relier à un service de recherche simple (mock ou Strapi) capable d’interroger entreprises, secteurs et provinces. Assurer l’accessibilité clavier, un input avec debounce et des placeholders i18n pour FR/EN."
+  },
+  {
+    "title": "Language switch UX & persistence",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Easy",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["i18n", "a11y", "good first issue"],
+    "body_en": "Refine the language switch component so that it uses @ngx-translate cleanly, persists the chosen locale (e.g. in localStorage or cookies) and behaves correctly with SSR. Avoid language flicker on first load and provide accessible labels for screen readers.",
+    "body_fr": "Améliorer le composant de changement de langue pour qu’il utilise @ngx-translate proprement, persiste la locale choisie (ex. dans localStorage ou cookie) et se comporte correctement avec SSR. Éviter le clignotement de langue au premier chargement et fournir des libellés accessibles pour les lecteurs d’écran."
+  },
+  {
+    "title": "Implement partner details panel layout",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["partners", "ui", "mat-drawer"],
+    "body_en": "Implement the partner details panel (drawer) layout with a clean structure: identity block, sectors, provinces served, capabilities and links (website, map). Use Angular standalone components, typed inputs and responsive Tailwind layout.",
+    "body_fr": "Implémenter la mise en page du panneau de détails partenaire (drawer) avec une structure claire : bloc identité, secteurs, provinces desservies, capacités et liens (site web, carte). Utiliser des composants standalone Angular, des inputs typés et une mise en page responsive avec Tailwind."
+  },
+  {
+    "title": "Partner quick-actions component",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Easy",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["partners", "cta", "good first issue"],
+    "body_en": "Create a partner quick-actions component that exposes CTAs such as \"Contact\", \"View on map\" and \"Bookmark\". No backend integration is required yet: emit strongly-typed events and/or router links so that parent components can decide the behaviour.",
+    "body_fr": "Créer un composant de raccourcis d’actions pour les partenaires avec des CTAs comme « Contacter », « Voir sur la carte » et « Ajouter aux favoris ». Aucune intégration backend n’est requise pour l’instant : émettre des événements fortement typés et/ou des routerLinks pour laisser le parent décider du comportement."
+  },
+  {
+    "title": "OG7 feed card & basic activity feed",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular) + CMS (Strapi)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org", "strapi"],
+    "agents_id": null,
+    "labels": ["feed", "ux", "humanitarian-2.0"],
+    "body_en": "Define a simple \"OpenG7 feed\" content type in Strapi (title, summary, type, tags, link, language) and implement an OG7 feed card component to display it on the homepage or a dedicated feed page. Prepare space to show economic updates, humanitarian calls and platform changes.",
+    "body_fr": "Définir un type de contenu « OpenG7 feed » dans Strapi (titre, résumé, type, tags, lien, langue) et implémenter un composant de carte OG7 feed pour l’afficher sur la page d’accueil ou une page dédiée. Préparer l’affichage d’actualités économiques, d’appels humanitaires et de mises à jour de la plateforme."
+  },
+  {
+    "title": "Citizen humanitarian report form (v1)",
+    "project_status": "Cadrage & Strategic ideas",
+    "track": "Front (Angular) + CMS (Strapi)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org", "strapi"],
+    "agents_id": null,
+    "labels": ["humanitarian-2.0", "forms", "a11y"],
+    "body_en": "Design the data model and first UI for a citizen humanitarian report form: location (city/region), short description, type of situation, optional contact and consent. Implement a static Angular form and a draft Strapi model that can evolve after feedback.",
+    "body_fr": "Concevoir le modèle de données et la première interface pour un formulaire de signalement humanitaire citoyen : lieu (ville/région), courte description, type de situation, contact optionnel et consentement. Implémenter un formulaire Angular statique et un modèle Strapi brouillon qui pourra évoluer après les premiers retours."
+  },
+  {
+    "title": "Humanitarian project calls listing",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular) + CMS (Strapi)",
+    "difficulty": "Medium",
+    "repos": ["openg7-org", "strapi"],
+    "agents_id": null,
+    "labels": ["humanitarian-2.0", "list", "filters"],
+    "body_en": "Create a \"Project Call\" content type in Strapi to describe humanitarian or reconstruction projects (location, sectors needed, funding type, deadlines) and implement a listing page with filters (province, sector, urgency). Focus on information architecture and clarity.",
+    "body_fr": "Créer un type de contenu « Project Call » dans Strapi pour décrire des projets humanitaires ou de reconstruction (lieu, secteurs requis, type de financement, échéances) et implémenter une page de liste avec filtres (province, secteur, urgence). Mettre l’accent sur l’architecture de l’information et la lisibilité."
+  },
+  {
+    "title": "Government & institutions information block",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Easy",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["content", "governance", "good first issue"],
+    "body_en": "Add a dedicated block on the homepage that explains the invitation to the Government of Canada and to financial institutions: why OpenG7 matters for sovereignty, risk management and collaboration. Reuse the official README copy and provide EN/FR versions.",
+    "body_fr": "Ajouter sur la page d’accueil un bloc dédié qui explique l’invitation adressée au gouvernement du Canada et aux institutions financières : pourquoi OpenG7 est important pour la souveraineté, la gestion des risques et la collaboration. Réutiliser le texte officiel du README et fournir des versions FR/EN."
+  },
+  {
+    "title": "Wise contribution & funding banner",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Easy",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["funding", "banner", "good first issue"],
+    "body_en": "Implement a discreet but visible banner or card that explains how to support the project financially (e.g. Wise link, GitHub Sponsors) and how funds are governed. Link to the financial governance page and keep the tone transparent and calm.",
+    "body_fr": "Implémenter une bannière ou carte discrète mais bien visible qui explique comment soutenir financièrement le projet (ex. lien Wise, GitHub Sponsors) et comment les fonds sont gouvernés. Lier vers la page de gouvernance financière et adopter un ton transparent et posé."
+  },
+  {
+    "title": "OpenG7 symbolic coin section (design & copy)",
+    "project_status": "Backlog validated",
+    "track": "Front (Angular)",
+    "difficulty": "Easy",
+    "repos": ["openg7-org"],
+    "agents_id": null,
+    "labels": ["branding", "content", "design"],
+    "body_en": "Create a section that presents the OpenG7 symbolic coin: image or illustration, meaning of each symbol (lion, sunrise, maple leaves, stars, etc.) and how it reflects economic sovereignty and cooperation. Text should be fully i18n-ready.",
+    "body_fr": "Créer une section qui présente la pièce symbolique OpenG7 : image ou illustration, signification de chaque symbole (lion, lever de soleil, feuilles d’érable, étoiles, etc.) et lien avec la souveraineté économique et la coopération. Le texte doit être entièrement prêt pour l’i18n."
+  },
+  {
+    "title": "Docs: How to run dev:all and full-stack loop",
+    "project_status": "Backlog validated",
+    "track": "Docs",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["docs", "good first issue"],
+    "body_en": "Write a short guide that explains the full-stack dev loop: how to run yarn dev:cms, yarn dev:web, yarn dev:all, what ports are used, and common issues (missing env, seeds). Target new contributors who just cloned the repo.",
+    "body_fr": "Rédiger un court guide qui explique la boucle de développement full-stack : comment lancer yarn dev:cms, yarn dev:web, yarn dev:all, quels ports sont utilisés et quels problèmes courants peuvent survenir (env manquante, seeds). Viser les nouveaux contributeurs qui viennent de cloner le dépôt."
+  },
+  {
+    "title": "Docs: Architecture overview for newcomers",
+    "project_status": "Backlog validated",
+    "track": "Docs",
+    "difficulty": "Easy",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["docs", "onboarding", "good first issue"],
+    "body_en": "Turn the current architecture description (front, Strapi, contracts, tooling, infra, docs) into a newcomer-friendly page with a diagram and short explanations for each workspace. Link to this page from the main README and CONTRIBUTING.",
+    "body_fr": "Transformer la description actuelle de l’architecture (front, Strapi, contracts, tooling, infra, docs) en une page accueillante pour les nouveaux arrivants avec un schéma et de courtes explications pour chaque workspace. Lier cette page depuis le README principal et CONTRIBUTING."
+  },
+  {
+    "title": "Infra: bootstrap CI workflow for monorepo scripts",
+    "project_status": "Cadrage & Strategic ideas",
+    "track": "Tooling / Infra",
+    "difficulty": "Medium",
+    "repos": ["infra", ".github"],
+    "agents_id": null,
+    "labels": ["ci", "monorepo", "tooling"],
+    "body_en": "Design a first combined CI workflow that runs the main monorepo scripts (lint, format:check, codegen, test, prebuild:web, etc.) and can later be extended with selectors/API validation. Document the trade-offs (runtime, caching, matrix strategy) in a short ADR.",
+    "body_fr": "Concevoir un premier workflow CI combiné qui exécute les principaux scripts du monorepo (lint, format:check, codegen, test, prebuild:web, etc.) et pourra être étendu plus tard avec la validation des sélecteurs/API. Documenter les compromis (durée, cache, stratégie de matrice) dans un court ADR."
+  },
+  {
+    "title": "Contracts: improve type coverage & docs",
+    "project_status": "Backlog validated",
+    "track": "Contracts",
+    "difficulty": "Medium",
+    "repos": ["packages/contracts"],
+    "agents_id": null,
+    "labels": ["openapi", "typescript", "contracts"],
+    "body_en": "Improve the @openg7/contracts package by ensuring strong type coverage for core entities (Province, Sector, Company, Exchange) and writing a README with import examples for Angular and Node scripts. Prepare for future OpenAPI-driven codegen.",
+    "body_fr": "Améliorer le package @openg7/contracts en garantissant une bonne couverture de types pour les entités clés (Province, Secteur, Entreprise, Échange) et en rédigeant un README avec des exemples d’import pour Angular et des scripts Node. Préparer le terrain pour un futur codegen basé sur OpenAPI."
+  },
+  {
+    "title": "Governance: publish financial governance page",
+    "project_status": "Cadrage & Strategic ideas",
+    "track": "Docs + Community",
+    "difficulty": "Medium",
+    "repos": ["docs"],
+    "agents_id": null,
+    "labels": ["governance", "finance", "community"],
+    "body_en": "Extract the financial governance rules (multi-signature, thresholds, audit principles) into a dedicated page under docs/ and describe how contributions (Wise, GitHub Sponsors, others) are managed. Keep language clear, non-legalistic and reassuring.",
+    "body_fr": "Extraire les règles de gouvernance financière (multi-signature, seuils, principes d’audit) dans une page dédiée sous docs/ et décrire la façon dont les contributions (Wise, GitHub Sponsors, autres) sont gérées. Utiliser un langage clair, non juridique et rassurant."
+  }
+]

--- a/tools/projects/seed-openg7-steering.ts
+++ b/tools/projects/seed-openg7-steering.ts
@@ -1,0 +1,319 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+interface WaveItem {
+  title: string;
+  project_status: string;
+  track: string;
+  difficulty: string;
+  repos: string[];
+  agents_id: string | null;
+  labels: string[];
+  body_en: string;
+  body_fr: string;
+}
+
+interface IssueSummary {
+  number: number;
+  node_id: string;
+  html_url: string;
+  title: string;
+}
+
+type SingleSelectKind = 'status' | 'track' | 'difficulty';
+
+type GraphQLError = {
+  message: string;
+};
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: GraphQLError[];
+};
+
+const TOKEN = process.env.GITHUB_TOKEN;
+const ORG = process.env.GITHUB_ORG ?? 'OpenG7';
+const PROJECT_ID = process.env.GITHUB_PROJECT_ID;
+
+if (!TOKEN) {
+  throw new Error('GITHUB_TOKEN is required');
+}
+
+if (!PROJECT_ID) {
+  throw new Error('GITHUB_PROJECT_ID is required');
+}
+
+const PROJECT_CONFIG = {
+  fields: {
+    status: 'STATUS_FIELD_ID',
+    track: 'TRACK_FIELD_ID',
+    difficulty: 'DIFFICULTY_FIELD_ID',
+    agentsId: 'AGENTS_ID_FIELD_ID',
+  },
+  options: {
+    status: {
+      'Backlog validated': 'OPTION_ID_STATUS_BACKLOG',
+      'Cadrage & Strategic ideas': 'OPTION_ID_STATUS_CADRAGE',
+      'Design & Multi-repo breakdown': 'OPTION_ID_STATUS_BREAKDOWN',
+      Todo: 'OPTION_ID_STATUS_TODO',
+      Doing: 'OPTION_ID_STATUS_DOING',
+      Done: 'OPTION_ID_STATUS_DONE',
+    },
+    track: {
+      'Front (Angular)': 'OPTION_ID_TRACK_FRONT',
+      'Front (Angular) + CMS (Strapi)': 'OPTION_ID_TRACK_FRONT_PLUS_CMS',
+      'CMS (Strapi)': 'OPTION_ID_TRACK_CMS',
+      'Docs': 'OPTION_ID_TRACK_DOCS',
+      'Docs + Community': 'OPTION_ID_TRACK_DOCS_COMMUNITY',
+      'Tooling / CI': 'OPTION_ID_TRACK_TOOLING',
+      'Contracts': 'OPTION_ID_TRACK_CONTRACTS',
+    },
+    difficulty: {
+      Easy: 'OPTION_ID_DIFFICULTY_EASY',
+      Medium: 'OPTION_ID_DIFFICULTY_MEDIUM',
+      Hard: 'OPTION_ID_DIFFICULTY_HARD',
+    },
+  },
+};
+
+async function ghRest<T>(pathName: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`https://api.github.com${pathName}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub REST error ${res.status}: ${text}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+async function ghGraphQL<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub GraphQL network error ${res.status}: ${text}`);
+  }
+
+  const json = (await res.json()) as GraphQLResponse<T>;
+  if (json.errors?.length) {
+    const messages = json.errors.map((err) => err.message).join('; ');
+    throw new Error(`GitHub GraphQL error: ${messages}`);
+  }
+
+  if (!json.data) {
+    throw new Error('GitHub GraphQL error: missing data');
+  }
+
+  return json.data;
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+async function loadWaveItems(): Promise<WaveItem[]> {
+  const filenames = [
+    path.resolve(process.cwd(), 'scripts/projects/openg7-steering-wave1.json'),
+    path.resolve(process.cwd(), 'scripts/projects/openg7-steering-wave2.json'),
+  ];
+
+  const contents = await Promise.all(filenames.map((file) => fs.readFile(file, 'utf-8')));
+  return contents.flatMap((content) => JSON.parse(content) as WaveItem[]);
+}
+
+async function findExistingIssueBySlug(repo: string, marker: string): Promise<IssueSummary | null> {
+  const query = `repo:${ORG}/${repo} "${marker}" in:body type:issue`;
+  const result = await ghRest<{ items: IssueSummary[] }>(`/search/issues?q=${encodeURIComponent(query)}`);
+  const match = result.items.find((issue) => issue.title && issue.html_url);
+
+  if (match) {
+    return match;
+  }
+
+  return null;
+}
+
+function buildIssueBody(item: WaveItem, marker: string): string {
+  return `## English\n${item.body_en}\n\n---\n\n## Français\n${item.body_fr}\n\n${marker}`;
+}
+
+async function createIssue(repo: string, item: WaveItem, marker: string): Promise<IssueSummary> {
+  const body = buildIssueBody(item, marker);
+  const issue = await ghRest<IssueSummary>(`/repos/${ORG}/${repo}/issues`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: item.title,
+      body,
+      labels: item.labels,
+    }),
+  });
+  console.log(`Created issue ${issue.html_url}`);
+  return issue;
+}
+
+async function findProjectItemId(issueNodeId: string): Promise<string | null> {
+  const query = `
+    query ($issueId: ID!) {
+      node(id: $issueId) {
+        ... on Issue {
+          projectItems(first: 20) {
+            nodes {
+              id
+              project { id }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await ghGraphQL<{ node?: { projectItems?: { nodes: { id: string; project?: { id: string } | null }[] } } } }>(
+    query,
+    { issueId: issueNodeId },
+  );
+
+  const nodes = data.node?.projectItems?.nodes ?? [];
+  const existing = nodes.find((node) => node.project?.id === PROJECT_ID);
+  return existing?.id ?? null;
+}
+
+async function addIssueToProject(issue: IssueSummary): Promise<string> {
+  const existing = await findProjectItemId(issue.node_id);
+  if (existing) {
+    console.log(`Issue already in project with item id ${existing}`);
+    return existing;
+  }
+
+  const mutation = `
+    mutation ($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }
+  `;
+
+  const data = await ghGraphQL<{ addProjectV2ItemById: { item: { id: string } } }>(mutation, {
+    projectId: PROJECT_ID,
+    contentId: issue.node_id,
+  });
+
+  const itemId = data.addProjectV2ItemById.item.id;
+  console.log(`Added to project item ${itemId}`);
+  return itemId;
+}
+
+async function setSingleSelectField(kind: SingleSelectKind, projectItemId: string, value: string): Promise<void> {
+  const fieldId = PROJECT_CONFIG.fields[kind];
+  const options = PROJECT_CONFIG.options[kind] as Record<string, string>;
+  const optionId = options[value];
+
+  if (!optionId) {
+    console.warn(`No option id configured for ${kind} value "${value}"`);
+    return;
+  }
+
+  const mutation = `
+    mutation ($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+  `;
+
+  await ghGraphQL(mutation, {
+    projectId: PROJECT_ID,
+    itemId: projectItemId,
+    fieldId,
+    optionId,
+  });
+
+  console.log(`Set ${kind}=${value} on project item ${projectItemId}`);
+}
+
+async function setTextField(projectItemId: string, value: string): Promise<void> {
+  const fieldId = PROJECT_CONFIG.fields.agentsId;
+
+  const mutation = `
+    mutation ($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+      updateProjectV2ItemFieldValue(
+        input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { text: $text } }
+      ) {
+        projectV2Item { id }
+      }
+    }
+  `;
+
+  await ghGraphQL(mutation, {
+    projectId: PROJECT_ID,
+    itemId: projectItemId,
+    fieldId,
+    text: value,
+  });
+
+  console.log(`Set AGENTS ID=${value} on project item ${projectItemId}`);
+}
+
+export async function main(): Promise<void> {
+  console.log('Loading wave items...');
+  const items = await loadWaveItems();
+
+  for (const item of items) {
+    for (const repo of item.repos) {
+      const slug = slugify(`${repo}-${item.title}`);
+      const marker = `<!-- og7-steering:${slug} -->`;
+
+      const existingIssue = await findExistingIssueBySlug(repo, marker);
+      let issue: IssueSummary;
+
+      if (existingIssue) {
+        console.log(`Found existing issue ${existingIssue.html_url}`);
+        issue = existingIssue;
+      } else {
+        issue = await createIssue(repo, item, marker);
+      }
+
+      const projectItemId = await addIssueToProject(issue);
+      await setSingleSelectField('status', projectItemId, item.project_status);
+      await setSingleSelectField('track', projectItemId, item.track);
+      await setSingleSelectField('difficulty', projectItemId, item.difficulty);
+
+      if (item.agents_id) {
+        await setTextField(projectItemId, item.agents_id);
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a script to seed issues and project items for the OpenG7 steering project
- add wave data JSON files under scripts/projects for the seeding workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929005a5458832ea9f79d65ee30906e)