### PR TITLE
feat: add new AI provider routes and workflows

### DIFF
--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -1,0 +1,173 @@
+name: Claude Branch and PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Instruction courte pour Claude (ex: corriger un bug, ajouter un test, mettre a jour une doc).'
+        required: true
+        type: string
+      scope:
+        description: 'Zone autorisee pour la premiere iteration.'
+        required: true
+        default: openg7-org
+        type: choice
+        options:
+          - openg7-org
+          - strapi
+          - packages-contracts
+          - packages-tooling
+          - repository-root
+      base_branch:
+        description: 'Branche de base pour la PR.'
+        required: true
+        default: main
+        type: string
+      draft_pr:
+        description: 'Ouvrir la PR en brouillon.'
+        required: true
+        default: true
+        type: boolean
+      model:
+        description: 'Modele Claude optionnel. Laisser vide pour le defaut du workflow.'
+        required: false
+        default: ''
+        type: string
+      effort:
+        description: 'Indication d effort optionnelle, transmise dans le prompt.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: claude-pr-${{ github.ref }}-${{ github.event.inputs.scope }}
+  cancel-in-progress: false
+
+jobs:
+  claude-pr:
+    name: Run Claude and open PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.base_branch }}
+          fetch-depth: 0
+
+      - name: Resolve allowed working directory
+        id: scope
+        shell: bash
+        run: |
+          case "${{ github.event.inputs.scope }}" in
+            openg7-org)
+              workdir="openg7-org"
+              ;;
+            strapi)
+              workdir="strapi"
+              ;;
+            packages-contracts)
+              workdir="packages/contracts"
+              ;;
+            packages-tooling)
+              workdir="packages/tooling"
+              ;;
+            repository-root)
+              workdir="."
+              ;;
+            *)
+              echo "Unsupported scope: ${{ github.event.inputs.scope }}" >&2
+              exit 1
+              ;;
+          esac
+
+          branch="claude/${{ github.event.inputs.scope }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "workdir=$workdir" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install workspace dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+
+      - name: Run Claude in selected scope
+        id: run_claude
+        uses: anthropics/claude-code-base-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: ${{ github.event.inputs.model || 'claude-sonnet-4-5' }}
+          allowed_tools: >-
+            Edit,Read,Write,Bash(git:*),Bash(yarn:*),Bash(npx:*),Bash(node:*),Bash(npm:*),Bash(pnpm:*),Bash(rg:*),Bash(ls:*),Bash(find:*)
+          prompt: |
+            You are preparing a focused repository change for OpenG7.
+
+            Requested task:
+            ${{ github.event.inputs.task }}
+
+            Required constraints:
+            - Follow the repository instructions in AGENTS.md.
+            - Prefer the smallest correct change that satisfies the task.
+            - Keep changes inside or adjacent to the selected scope when possible: ${{ steps.scope.outputs.workdir }}.
+            - Restrict edits to files under `${{ steps.scope.outputs.workdir }}` unless a directly adjacent shared contract, test, route constant, or runtime config must also change.
+            - Do not modify secrets, workflow tokens, deployment credentials, or unrelated files.
+            - Run the narrowest validation that proves the edited slice works.
+            - If the request is ambiguous, unsafe, or cannot be completed confidently, do not guess. Explain the blocker in the final message.
+            - If the optional effort hint is provided, treat it as guidance only: `${{ github.event.inputs.effort }}`.
+
+            Git context:
+            - Base branch: ${{ github.event.inputs.base_branch }}
+            - Branch to publish: ${{ steps.scope.outputs.branch }}
+            - Triggered by: @${{ github.actor }}
+
+            Final message format:
+            Summary: short paragraph
+            Validation: commands run and results
+            Risks: only if material risks remain
+
+      - name: Create pull request from Claude changes
+        id: create_pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          base: ${{ github.event.inputs.base_branch }}
+          branch: ${{ steps.scope.outputs.branch }}
+          commit-message: 'chore(claude): ${{ github.event.inputs.task }}'
+          title: 'Claude: ${{ github.event.inputs.task }}'
+          draft: ${{ github.event.inputs.draft_pr }}
+          delete-branch: true
+          body: |
+            ## Claude run
+
+            - Triggered by: @${{ github.actor }}
+            - Scope: `${{ github.event.inputs.scope }}`
+            - Working directory target: `${{ steps.scope.outputs.workdir }}`
+            - Base branch: `${{ github.event.inputs.base_branch }}`
+            - Workflow run: `${{ github.run_id }}`
+
+            Review the workflow logs for the complete Claude transcript and validations.
+
+      - name: Publish workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Claude Branch and PR"
+            echo
+            echo "- Scope: ${{ github.event.inputs.scope }}"
+            echo "- Working directory target: ${{ steps.scope.outputs.workdir }}"
+            echo "- Base branch: ${{ github.event.inputs.base_branch }}"
+            if [ -n "${{ steps.create_pr.outputs.pull-request-url }}" ]; then
+              echo "- Pull request: ${{ steps.create_pr.outputs.pull-request-url }}"
+            else
+              echo "- Pull request: no code change detected or PR not created"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/copilot-pr.yml
+++ b/.github/workflows/copilot-pr.yml
@@ -1,0 +1,73 @@
+name: Copilot Branch and PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Instruction courte pour Copilot.'
+        required: true
+        type: string
+      scope:
+        description: 'Zone demandee pour la tentative de delegation.'
+        required: true
+        default: openg7-org
+        type: choice
+        options:
+          - openg7-org
+          - strapi
+          - packages-contracts
+          - packages-tooling
+          - repository-root
+      base_branch:
+        description: 'Branche de base pour la PR.'
+        required: true
+        default: main
+        type: string
+      draft_pr:
+        description: 'Ouvrir la PR en brouillon.'
+        required: true
+        default: true
+        type: boolean
+      model:
+        description: 'Modele GitHub optionnel.'
+        required: false
+        default: ''
+        type: string
+      effort:
+        description: 'Indication d effort optionnelle.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: copilot-pr-${{ github.ref }}-${{ github.event.inputs.scope }}
+  cancel-in-progress: false
+
+jobs:
+  copilot-pr:
+    name: Fail fast until a supported Copilot runner is wired
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain current limitation
+        shell: bash
+        run: |
+          {
+            echo "## Copilot Branch and PR"
+            echo
+            echo "This workflow is intentionally a guarded placeholder."
+            echo
+            echo "GitHub Copilot coding agent does not currently expose a stable repository workflow action or CLI surface in this codebase that can be wired with the same branch-and-PR automation contract as Codex, Claude, or Gemini."
+            echo
+            echo "Current request:"
+            echo "- Scope: ${{ github.event.inputs.scope }}"
+            echo "- Base branch: ${{ github.event.inputs.base_branch }}"
+            echo "- Task: ${{ github.event.inputs.task }}"
+            echo
+            echo "Keep OPS_AI_COPILOT_DISPATCH_ENABLED=false until a supported automation runner is available."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Copilot workflow dispatch is not implemented in GitHub Actions for this repository yet." >&2
+          exit 1

--- a/.github/workflows/gemini-pr.yml
+++ b/.github/workflows/gemini-pr.yml
@@ -1,0 +1,173 @@
+name: Gemini Branch and PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Instruction courte pour Gemini (ex: corriger un bug, ajouter un test, mettre a jour une doc).'
+        required: true
+        type: string
+      scope:
+        description: 'Zone autorisee pour la premiere iteration.'
+        required: true
+        default: openg7-org
+        type: choice
+        options:
+          - openg7-org
+          - strapi
+          - packages-contracts
+          - packages-tooling
+          - repository-root
+      base_branch:
+        description: 'Branche de base pour la PR.'
+        required: true
+        default: main
+        type: string
+      draft_pr:
+        description: 'Ouvrir la PR en brouillon.'
+        required: true
+        default: true
+        type: boolean
+      model:
+        description: 'Modele Gemini optionnel. Laisser vide pour le defaut du workflow.'
+        required: false
+        default: ''
+        type: string
+      effort:
+        description: 'Indication d effort optionnelle, transmise dans le prompt.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: gemini-pr-${{ github.ref }}-${{ github.event.inputs.scope }}
+  cancel-in-progress: false
+
+jobs:
+  gemini-pr:
+    name: Run Gemini and open PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.base_branch }}
+          fetch-depth: 0
+
+      - name: Resolve allowed working directory
+        id: scope
+        shell: bash
+        run: |
+          case "${{ github.event.inputs.scope }}" in
+            openg7-org)
+              workdir="openg7-org"
+              ;;
+            strapi)
+              workdir="strapi"
+              ;;
+            packages-contracts)
+              workdir="packages/contracts"
+              ;;
+            packages-tooling)
+              workdir="packages/tooling"
+              ;;
+            repository-root)
+              workdir="."
+              ;;
+            *)
+              echo "Unsupported scope: ${{ github.event.inputs.scope }}" >&2
+              exit 1
+              ;;
+          esac
+
+          branch="gemini/${{ github.event.inputs.scope }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "workdir=$workdir" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install workspace dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+
+      - name: Run Gemini in selected scope
+        id: run_gemini
+        uses: google-github-actions/run-gemini-cli@v0
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_model: ${{ github.event.inputs.model || 'gemini-2.5-pro' }}
+          prompt: |-
+            You are preparing a focused repository change for OpenG7.
+
+            Requested task:
+            ${{ github.event.inputs.task }}
+
+            Required constraints:
+            - Follow the repository instructions in AGENTS.md.
+            - Prefer the smallest correct change that satisfies the task.
+            - Keep changes inside or adjacent to the selected scope when possible: ${{ steps.scope.outputs.workdir }}.
+            - Restrict edits to files under `${{ steps.scope.outputs.workdir }}` unless a directly adjacent shared contract, test, route constant, or runtime config must also change.
+            - Do not modify secrets, workflow tokens, deployment credentials, or unrelated files.
+            - Run the narrowest validation that proves the edited slice works.
+            - If the request is ambiguous, unsafe, or cannot be completed confidently, do not guess. Explain the blocker in the final message.
+            - If the optional effort hint is provided, treat it as guidance only: `${{ github.event.inputs.effort }}`.
+
+            Git context:
+            - Base branch: ${{ github.event.inputs.base_branch }}
+            - Branch to publish: ${{ steps.scope.outputs.branch }}
+            - Triggered by: @${{ github.actor }}
+
+            Final response format:
+            Summary: short paragraph
+            Validation: commands run and results
+            Risks: only if material risks remain
+
+      - name: Create pull request from Gemini changes
+        id: create_pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          base: ${{ github.event.inputs.base_branch }}
+          branch: ${{ steps.scope.outputs.branch }}
+          commit-message: 'chore(gemini): ${{ github.event.inputs.task }}'
+          title: 'Gemini: ${{ github.event.inputs.task }}'
+          draft: ${{ github.event.inputs.draft_pr }}
+          delete-branch: true
+          body: |
+            ## Gemini run
+
+            - Triggered by: @${{ github.actor }}
+            - Scope: `${{ github.event.inputs.scope }}`
+            - Working directory target: `${{ steps.scope.outputs.workdir }}`
+            - Base branch: `${{ github.event.inputs.base_branch }}`
+            - Workflow run: `${{ github.run_id }}`
+
+            ## Gemini summary
+
+            ${{ steps.run_gemini.outputs.summary }}
+
+      - name: Publish workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Gemini Branch and PR"
+            echo
+            echo "- Scope: ${{ github.event.inputs.scope }}"
+            echo "- Working directory target: ${{ steps.scope.outputs.workdir }}"
+            echo "- Base branch: ${{ github.event.inputs.base_branch }}"
+            if [ -n "${{ steps.create_pr.outputs.pull-request-url }}" ]; then
+              echo "- Pull request: ${{ steps.create_pr.outputs.pull-request-url }}"
+            else
+              echo "- Pull request: no code change detected or PR not created"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ Detailed guides live in `docs/`:
 The platform includes admin operations surfaces for monitoring runtime health and platform status.
 
 - Frontend route: `/admin/ops` for the admin UI
+- Frontend route: `/admin/quality` for Mission Control dispatches backed by Ops readiness
 - API endpoints:
   - `GET /api/admin/ops/health`
   - `GET /api/admin/ops/backups`
   - `GET /api/admin/ops/imports`
   - `GET /api/admin/ops/security`
+  - `POST /api/admin/ops/ai/dispatch`
   - `POST /api/admin/ops/codex/dispatch`
 - API policy: `global::owner-admin-ops`
 - API access: roles `Admin` and `Owner`

--- a/docs/strapi/admin-ops-codex-dispatch.md
+++ b/docs/strapi/admin-ops-codex-dispatch.md
@@ -1,17 +1,76 @@
-# Admin Ops Codex Dispatch
+# Admin Ops AI Dispatch
 
-This guide documents the Strapi backend endpoint used to trigger the GitHub Actions Codex v1 workflow from an owner/admin surface.
+This guide documents the Strapi backend endpoint used to trigger provider-specific GitHub Actions workflows from an owner/admin surface.
 
 ## Endpoint
 
-- `POST /api/admin/ops/codex/dispatch`
+- `GET /api/admin/ops/ai/proofs`
+- `POST /api/admin/ops/ai/dispatch`
+- Compatibility alias: `POST /api/admin/ops/codex/dispatch`
 - Auth: authenticated user with role `Admin` or `Owner`
 - Policy: `global::owner-admin-ops`
+
+## Proof telemetry response
+
+`GET /api/admin/ops/ai/proofs` returns the latest observable GitHub evidence for each provider workflow. The response is read-only and meant for Mission Control / Ops dashboards.
+
+```json
+{
+  "data": {
+    "generatedAt": "2026-04-30T12:00:00.000Z",
+    "providers": [
+      {
+        "provider": "codex",
+        "label": "Codex",
+        "workflow": "codex-pr.yml",
+        "state": "completed",
+        "summary": "Workflow #51 completed with 2 artifact(s) and PR #321.",
+        "run": {
+          "id": 501,
+          "number": 51,
+          "url": "https://github.com/OpenG7/openg7-platform/actions/runs/501",
+          "status": "completed",
+          "conclusion": "success",
+          "branch": "codex/qa-proof-501",
+          "createdAt": "2026-04-30T00:00:00.000Z",
+          "updatedAt": "2026-04-30T00:08:00.000Z"
+        },
+        "artifacts": [
+          {
+            "id": 9001,
+            "name": "playwright-report",
+            "sizeBytes": 2048,
+            "expired": false,
+            "url": "https://github.com/OpenG7/openg7-platform/actions/runs/501#artifacts"
+          }
+        ],
+        "pullRequest": {
+          "number": 321,
+          "title": "Codex QA proof package",
+          "url": "https://github.com/OpenG7/openg7-platform/pull/321",
+          "state": "open",
+          "merged": false,
+          "branch": "codex/qa-proof-501"
+        }
+      }
+    ]
+  }
+}
+```
+
+States are intentionally coarse:
+
+- `queued` -> the workflow has been accepted by GitHub and is waiting to start.
+- `in-progress` -> the provider lane is actively generating proof.
+- `completed` -> the latest run finished successfully and artifacts/PR evidence can be reviewed.
+- `failed` -> the latest run finished but did not conclude successfully.
+- `unavailable` -> no run is observable yet or GitHub monitoring is not configured.
 
 ## Request payload
 
 ```json
 {
+  "provider": "copilot",
   "task": "Fix the login empty state and add a focused test.",
   "scope": "openg7-org",
   "baseBranch": "main",
@@ -23,9 +82,10 @@ This guide documents the Strapi backend endpoint used to trigger the GitHub Acti
 
 ## Validation rules
 
+- `provider` accepts `codex`, `copilot`, `claude`, or `gemini`. Omit it to keep the legacy `codex` default.
 - `task` is required and trimmed to 2000 characters.
-- `scope` must belong to `OPS_CODEX_ALLOWED_SCOPES`.
-- `baseBranch` must belong to `OPS_CODEX_ALLOWED_BASE_BRANCHES`.
+- `scope` must belong to the allowlist resolved for the selected provider.
+- `baseBranch` must belong to the branch allowlist resolved for the selected provider.
 - `draftPr` defaults to `true`.
 - `model` and `effort` are optional pass-through fields.
 
@@ -42,11 +102,30 @@ This guide documents the Strapi backend endpoint used to trigger the GitHub Acti
 - `OPS_CODEX_ALLOWED_BASE_BRANCHES` - comma-separated allowlist of base branches accepted from callers.
 - `OPS_CODEX_TIMEOUT_MS` - outbound GitHub API timeout in milliseconds.
 
+Optional multi-provider overrides use the `OPS_AI_*` namespace:
+
+- `OPS_AI_GITHUB_TOKEN`, `OPS_AI_GITHUB_OWNER`, `OPS_AI_GITHUB_REPO`, `OPS_AI_GITHUB_API_URL`
+- `OPS_AI_ALLOWED_SCOPES`, `OPS_AI_ALLOWED_BASE_BRANCHES`, `OPS_AI_TIMEOUT_MS`
+- `OPS_AI_<PROVIDER>_DISPATCH_ENABLED`
+- `OPS_AI_<PROVIDER>_GITHUB_WORKFLOW`
+- `OPS_AI_<PROVIDER>_GITHUB_REF`
+
+`<PROVIDER>` can be `COPILOT`, `CLAUDE`, or `GEMINI`. Non-Codex providers fall back to `OPS_AI_*` first and then to the legacy `OPS_CODEX_*` values for shared GitHub owner/repo/token settings.
+
+## Workflow files and provider secrets
+
+- `codex` -> `.github/workflows/codex-pr.yml` using `OPENAI_API_KEY`
+- `claude` -> `.github/workflows/claude-pr.yml` using `ANTHROPIC_API_KEY`
+- `gemini` -> `.github/workflows/gemini-pr.yml` using `GEMINI_API_KEY` by default; adapt the workflow if you prefer Vertex AI or Gemini Code Assist via repository variables
+- `copilot` -> `.github/workflows/copilot-pr.yml` is a guarded placeholder that fails fast on purpose; keep `OPS_AI_COPILOT_DISPATCH_ENABLED=false` until GitHub exposes a stable automation surface for Copilot branch-and-PR runs in this repository
+
+The Claude and Gemini workflows mirror the existing Codex flow: checkout the requested base branch, constrain the prompt to the selected scope, let the provider edit the repo, then open a PR with `peter-evans/create-pull-request`.
+
 ## Kubernetes wiring
 
 The production manifest now exposes the non-secret settings through the shared Strapi `ConfigMap` and expects the GitHub token from the Kubernetes secret `strapi-github-actions` under the key `codex-github-token`.
 
-The deployment keeps the secret optional so environments that do not use the Codex control plane can leave it unset while `OPS_CODEX_DISPATCH_ENABLED=false`.
+The deployment keeps the secret optional so environments that do not use AI dispatch can leave it unset while all dispatch flags remain `false`.
 
 ## Response shape
 
@@ -57,12 +136,14 @@ Successful responses return a small queue acknowledgement:
   "data": {
     "queued": true,
     "provider": "github-actions",
+    "selectedProvider": "copilot",
     "owner": "OpenG7",
     "repo": "openg7-platform",
-    "workflow": "codex-pr.yml",
+    "workflow": "copilot-pr.yml",
     "ref": "main",
     "requestedAt": "2026-04-25T12:00:00.000Z",
     "request": {
+      "selectedProvider": "copilot",
       "scope": "openg7-org",
       "baseBranch": "main",
       "draftPr": true,
@@ -80,14 +161,25 @@ Successful responses return a small queue acknowledgement:
 - `403` when the authenticated user is not `Admin` or `Owner`.
 - `503` when the integration is disabled or missing required GitHub configuration.
 - `502` when GitHub rejects or times out the workflow dispatch.
+- A dispatched workflow run can still fail later if the provider-specific secret is missing or, for `copilot`, if the placeholder workflow is enabled accidentally.
+
+## Admin quality launch path
+
+`/admin/quality` now uses the same backend control point instead of relying on a local quota estimate:
+
+- Mission Control reads `/api/admin/ops/security` and only arms the launch action when the selected provider has `dispatchEnabled=true`, `keyInserted=true`, and `state="ready"`.
+- Mission Control also reads `/api/admin/ops/ai/proofs` to surface the latest workflow run, PR lane, and artifact package for each provider.
+- The launch button dispatches the selected mission directly through `POST /api/admin/ops/ai/dispatch` after an explicit browser confirmation.
+- The prompt, scope, base branch, draft PR flag, model, and provider are still the same fields shown in `/admin/ops`; `/admin/ops` remains the manual inspection and retry surface.
+- Mission status changes to `in-progress` only after the backend has accepted the GitHub workflow dispatch.
 
 ## Operating model
 
 This endpoint is intentionally thin:
 
 - Strapi validates operator intent.
-- GitHub keeps the `OPENAI_API_KEY` secret and executes Codex.
+- GitHub keeps provider secrets and executes the selected workflow.
 - The workflow creates a dedicated branch and opens a PR.
 - Human review still gates merge.
 
-That keeps Codex secrets and branch automation outside the Angular app while giving OpenG7 a single backend control point for audits and future rate limiting.
+That keeps AI provider secrets and branch automation outside the Angular app while giving OpenG7 a single backend control point for audits and future rate limiting.

--- a/infra/kubernetes/strapi.yaml
+++ b/infra/kubernetes/strapi.yaml
@@ -104,6 +104,21 @@ data:
   OPS_CODEX_ALLOWED_SCOPES: openg7-org,strapi,packages-contracts,packages-tooling,repository-root
   OPS_CODEX_ALLOWED_BASE_BRANCHES: main
   OPS_CODEX_TIMEOUT_MS: '10000'
+  OPS_AI_GITHUB_OWNER: OpenG7
+  OPS_AI_GITHUB_REPO: openg7-platform
+  OPS_AI_GITHUB_API_URL: https://api.github.com
+  OPS_AI_ALLOWED_SCOPES: openg7-org,strapi,packages-contracts,packages-tooling,repository-root
+  OPS_AI_ALLOWED_BASE_BRANCHES: main
+  OPS_AI_TIMEOUT_MS: '10000'
+  OPS_AI_COPILOT_DISPATCH_ENABLED: 'false'
+  OPS_AI_COPILOT_GITHUB_WORKFLOW: copilot-pr.yml
+  OPS_AI_COPILOT_GITHUB_REF: main
+  OPS_AI_CLAUDE_DISPATCH_ENABLED: 'false'
+  OPS_AI_CLAUDE_GITHUB_WORKFLOW: claude-pr.yml
+  OPS_AI_CLAUDE_GITHUB_REF: main
+  OPS_AI_GEMINI_DISPATCH_ENABLED: 'false'
+  OPS_AI_GEMINI_GITHUB_WORKFLOW: gemini-pr.yml
+  OPS_AI_GEMINI_GITHUB_REF: main
   DATABASE_CLIENT: postgres
   DATABASE_HOST: openg7-postgres
   DATABASE_PORT: '5432'
@@ -187,6 +202,12 @@ spec:
                   name: openg7-redis-secret
                   key: password
             - name: OPS_CODEX_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: strapi-github-actions
+                  key: codex-github-token
+                  optional: true
+            - name: OPS_AI_GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: strapi-github-actions

--- a/openg7-org/src/app/core/api/strapi.routes.ts
+++ b/openg7-org/src/app/core/api/strapi.routes.ts
@@ -27,6 +27,8 @@ export const STRAPI_ROUTES = {
     opsBackups: '/api/admin/ops/backups',
     opsImports: '/api/admin/ops/imports',
     opsSecurity: '/api/admin/ops/security',
+    opsAiProofs: '/api/admin/ops/ai/proofs',
+    opsAiDispatch: '/api/admin/ops/ai/dispatch',
     opsCodexDispatch: '/api/admin/ops/codex/dispatch',
     qualityMissionDecisions: '/api/admin/quality/mission-decisions',
   },

--- a/openg7-org/src/app/domains/admin/data-access/admin-ai-providers.ts
+++ b/openg7-org/src/app/domains/admin/data-access/admin-ai-providers.ts
@@ -1,0 +1,61 @@
+export type AdminAiProvider = 'codex' | 'copilot' | 'claude' | 'gemini';
+
+export interface AdminAiProviderOption {
+  readonly id: AdminAiProvider;
+  readonly label: string;
+  readonly caption: string;
+  readonly defaultModel: string;
+  readonly defaultQuotaUnits: number;
+}
+
+export const ADMIN_AI_PROVIDER_OPTIONS: readonly AdminAiProviderOption[] = [
+  {
+    id: 'codex',
+    label: 'Codex',
+    caption: 'Workflow GitHub natif de reference pour les delegations automatisees.',
+    defaultModel: 'gpt-5.4',
+    defaultQuotaUnits: 160,
+  },
+  {
+    id: 'copilot',
+    label: 'GitHub Copilot',
+    caption: 'Bon relais quand le quota Codex est sature et qu il faut rester dans l environnement GitHub.',
+    defaultModel: 'gpt-5.4',
+    defaultQuotaUnits: 180,
+  },
+  {
+    id: 'claude',
+    label: 'Claude',
+    caption: 'Utile pour des briefs longs et une relecture structuree avant delegation.',
+    defaultModel: 'claude-sonnet-4-5',
+    defaultQuotaUnits: 140,
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini',
+    caption: 'Pratique pour basculer rapidement sur une autre reserve de quota orientee synthesis.',
+    defaultModel: 'gemini-2.5-pro',
+    defaultQuotaUnits: 140,
+  },
+] as const;
+
+export function buildAdminAiQuotaDefaults(): Record<AdminAiProvider, number> {
+  return ADMIN_AI_PROVIDER_OPTIONS.reduce(
+    (accumulator, option) => ({
+      ...accumulator,
+      [option.id]: option.defaultQuotaUnits,
+    }),
+    {} as Record<AdminAiProvider, number>,
+  );
+}
+
+export function isAdminAiProvider(value: unknown): value is AdminAiProvider {
+  return ADMIN_AI_PROVIDER_OPTIONS.some((option) => option.id === value);
+}
+
+export function resolveAdminAiProviderOption(provider: AdminAiProvider): AdminAiProviderOption {
+  return (
+    ADMIN_AI_PROVIDER_OPTIONS.find((option) => option.id === provider) ??
+    ADMIN_AI_PROVIDER_OPTIONS[0]
+  );
+}

--- a/openg7-org/src/app/domains/admin/data-access/admin-ops.service.spec.ts
+++ b/openg7-org/src/app/domains/admin/data-access/admin-ops.service.spec.ts
@@ -43,6 +43,7 @@ describe('AdminOpsService', () => {
   it('posts Codex workflow dispatches to the admin ops endpoint with silent error handling', () => {
     service
       .dispatchCodexWorkflow({
+        provider: 'codex',
         task: 'Fix the login empty state and add a focused test.',
         scope: 'openg7-org',
         baseBranch: 'main',
@@ -55,10 +56,11 @@ describe('AdminOpsService', () => {
         expect(response.workflow).toBe('codex-pr.yml');
       });
 
-    const request = httpMock.expectOne('https://cms.local/api/admin/ops/codex/dispatch');
+    const request = httpMock.expectOne('https://cms.local/api/admin/ops/ai/dispatch');
     expect(request.request.method).toBe('POST');
     expect(request.request.context.get(SUPPRESS_ERROR_TOAST)).toBeTrue();
     expect(request.request.body).toEqual({
+      provider: 'codex',
       task: 'Fix the login empty state and add a focused test.',
       scope: 'openg7-org',
       baseBranch: 'main',
@@ -71,12 +73,14 @@ describe('AdminOpsService', () => {
       data: {
         queued: true,
         provider: 'github-actions',
+        selectedProvider: 'codex',
         owner: 'OpenG7',
         repo: 'openg7-platform',
         workflow: 'codex-pr.yml',
         ref: 'main',
         requestedAt: '2026-04-26T00:00:00.000Z',
         request: {
+          selectedProvider: 'codex',
           scope: 'openg7-org',
           baseBranch: 'main',
           draftPr: true,
@@ -84,6 +88,59 @@ describe('AdminOpsService', () => {
           effort: 'medium',
           taskLength: 49,
         },
+      },
+    });
+  });
+
+  it('reads AI proof snapshots from the admin ops proofs endpoint', () => {
+    service.getAiProofs().subscribe((response) => {
+      expect(response.providers.length).toBe(1);
+      expect(response.providers[0]?.provider).toBe('codex');
+      expect(response.providers[0]?.artifacts.length).toBe(1);
+    });
+
+    const request = httpMock.expectOne('https://cms.local/api/admin/ops/ai/proofs');
+    expect(request.request.method).toBe('GET');
+
+    request.flush({
+      data: {
+        generatedAt: '2026-04-30T00:00:00.000Z',
+        providers: [
+          {
+            provider: 'codex',
+            label: 'Codex',
+            workflow: 'codex-pr.yml',
+            state: 'completed',
+            summary: 'Workflow #51 completed with 1 artifact.',
+            run: {
+              id: 501,
+              number: 51,
+              url: 'https://github.com/OpenG7/openg7-platform/actions/runs/501',
+              status: 'completed',
+              conclusion: 'success',
+              branch: 'codex/qa-proof-501',
+              createdAt: '2026-04-30T00:00:00.000Z',
+              updatedAt: '2026-04-30T00:08:00.000Z',
+            },
+            artifacts: [
+              {
+                id: 9001,
+                name: 'playwright-report',
+                sizeBytes: 2048,
+                expired: false,
+                url: 'https://github.com/OpenG7/openg7-platform/actions/runs/501#artifacts',
+              },
+            ],
+            pullRequest: {
+              number: 321,
+              title: 'Codex QA proof package',
+              url: 'https://github.com/OpenG7/openg7-platform/pull/321',
+              state: 'open',
+              merged: false,
+              branch: 'codex/qa-proof-501',
+            },
+          },
+        ],
       },
     });
   });

--- a/openg7-org/src/app/domains/admin/data-access/admin-ops.service.ts
+++ b/openg7-org/src/app/domains/admin/data-access/admin-ops.service.ts
@@ -5,6 +5,8 @@ import { SUPPRESS_ERROR_TOAST } from '@app/core/http/error.interceptor.tokens';
 import { HttpClientService } from '@app/core/http/http-client.service';
 import { forkJoin, map, Observable } from 'rxjs';
 
+import { AdminAiProvider } from './admin-ai-providers';
+
 export type AdminOpsCodexScope =
   | 'openg7-org'
   | 'strapi'
@@ -97,10 +99,64 @@ export interface AdminOpsSecuritySnapshot {
   auth: {
     sessionIdleTimeoutMs: number | null;
   };
+  aiKeys: Array<{
+    provider: AdminAiProvider;
+    label: string;
+    workflow: string;
+    secretName: string | null;
+    dispatchEnabled: boolean;
+    keyInserted: boolean;
+    state: 'ready' | 'offline' | 'scan-unavailable' | 'unsupported';
+    note: string;
+  }>;
   moderation: {
     pendingCompanies: number;
     suspendedCompanies: number;
   };
+}
+
+export interface AdminOpsAiProofArtifact {
+  id: number | null;
+  name: string;
+  sizeBytes: number;
+  expired: boolean;
+  url: string | null;
+}
+
+export interface AdminOpsAiProofPullRequest {
+  number: number | null;
+  title: string;
+  url: string | null;
+  state: string;
+  merged: boolean;
+  branch: string | null;
+}
+
+export interface AdminOpsAiProofRun {
+  id: number | null;
+  number: number | null;
+  url: string | null;
+  status: string | null;
+  conclusion: string | null;
+  branch: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface AdminOpsAiProofProviderSnapshot {
+  provider: AdminAiProvider;
+  label: string;
+  workflow: string;
+  state: 'queued' | 'in-progress' | 'completed' | 'failed' | 'unavailable';
+  summary: string;
+  run: AdminOpsAiProofRun | null;
+  artifacts: AdminOpsAiProofArtifact[];
+  pullRequest: AdminOpsAiProofPullRequest | null;
+}
+
+export interface AdminOpsAiProofSnapshot {
+  generatedAt: string;
+  providers: AdminOpsAiProofProviderSnapshot[];
 }
 
 export interface AdminOpsSnapshot {
@@ -111,6 +167,7 @@ export interface AdminOpsSnapshot {
 }
 
 export interface AdminOpsCodexDispatchRequest {
+  provider: AdminAiProvider;
   task: string;
   scope: AdminOpsCodexScope;
   baseBranch: string;
@@ -122,12 +179,14 @@ export interface AdminOpsCodexDispatchRequest {
 export interface AdminOpsCodexDispatchResponse {
   queued: boolean;
   provider: 'github-actions';
+  selectedProvider: AdminAiProvider;
   owner: string;
   repo: string;
   workflow: string;
   ref: string;
   requestedAt: string;
   request: {
+    selectedProvider: AdminAiProvider;
     scope: AdminOpsCodexScope;
     baseBranch: string;
     draftPr: boolean;
@@ -169,12 +228,18 @@ export class AdminOpsService {
       .pipe(map((response) => response.data));
   }
 
+  getAiProofs(): Observable<AdminOpsAiProofSnapshot> {
+    return this.http
+      .get<StrapiDataResponse<AdminOpsAiProofSnapshot>>(STRAPI_ROUTES.admin.opsAiProofs)
+      .pipe(map((response) => response.data));
+  }
+
   dispatchCodexWorkflow(
     payload: AdminOpsCodexDispatchRequest,
   ): Observable<AdminOpsCodexDispatchResponse> {
     return this.http
       .post<StrapiDataResponse<AdminOpsCodexDispatchResponse>>(
-        STRAPI_ROUTES.admin.opsCodexDispatch,
+        STRAPI_ROUTES.admin.opsAiDispatch,
         payload,
         {
           context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true),

--- a/openg7-org/src/app/domains/admin/pages/admin-ops.page.html
+++ b/openg7-org/src/app/domains/admin/pages/admin-ops.page.html
@@ -5,6 +5,36 @@
       <p class="text-sm text-slate-600">
         Monitor platform health, backups, import throughput and security indicators in one place.
       </p>
+      <div class="flex flex-wrap items-center gap-3 text-xs">
+        <span
+          class="inline-flex items-center gap-2 rounded-full border px-3 py-1 font-semibold"
+          data-og7-id="admin-ops-live-status"
+          [attr.data-og7-state]="liveTelemetryState()"
+          [class.border-emerald-200]="isLiveTelemetry('live')"
+          [class.bg-emerald-50]="isLiveTelemetry('live')"
+          [class.text-emerald-700]="isLiveTelemetry('live')"
+          [class.border-amber-200]="isLiveTelemetry('degraded') || isLiveTelemetry('syncing')"
+          [class.bg-amber-50]="isLiveTelemetry('degraded') || isLiveTelemetry('syncing')"
+          [class.text-amber-700]="isLiveTelemetry('degraded') || isLiveTelemetry('syncing')"
+          [class.border-slate-200]="isLiveTelemetry('offline')"
+          [class.bg-slate-50]="isLiveTelemetry('offline')"
+          [class.text-slate-600]="isLiveTelemetry('offline')"
+        >
+          <span
+            class="h-2.5 w-2.5 rounded-full"
+            [class.og7-live-heartbeat]="isLiveTelemetry('live')"
+            [class.og7-live-heartbeat--degraded]="isLiveTelemetry('degraded')"
+            [class.og7-live-heartbeat--syncing]="isLiveTelemetry('syncing')"
+            [class.bg-emerald-500]="isLiveTelemetry('live')"
+            [class.bg-amber-500]="isLiveTelemetry('degraded') || isLiveTelemetry('syncing')"
+            [class.bg-slate-400]="isLiveTelemetry('offline')"
+          ></span>
+          {{ liveTelemetryLabel() }}
+        </span>
+        <span class="text-slate-500" data-og7-id="admin-ops-live-detail">
+          {{ liveTelemetryDetail() }}
+        </span>
+      </div>
       @if (lastUpdated(); as timestamp) {
       <p class="text-xs text-slate-500" data-og7-id="admin-ops-last-updated">
         Last update: {{ timestamp | date: 'yyyy-MM-dd HH:mm:ss' }}
@@ -44,17 +74,235 @@
   >
     <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
-        <h2 class="text-base font-semibold text-slate-900">Codex dispatch</h2>
+        <h2 class="text-base font-semibold text-slate-900">AI dispatch</h2>
         <p class="text-sm text-slate-600">
-          Queue a focused GitHub Actions run from the owner/admin control plane. The workflow
-          creates a dedicated branch and opens a PR.
+          Switch between approved AI copilots, keep the task brief ready, and queue the owner/admin
+          workflow from the same control plane.
         </p>
       </div>
       <span
         class="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600"
       >
-        Endpoint: /api/admin/ops/codex/dispatch
+        Execution endpoint: /api/admin/ops/ai/dispatch
       </span>
+    </div>
+
+    <div class="mt-4 rounded-lg border border-sky-100 bg-sky-50 px-4 py-3 text-sm text-sky-900">
+      <p class="font-medium" data-og7-id="admin-ops-provider-label">
+        Active AI: {{ dispatchProviderLabel() }}
+      </p>
+      <p class="mt-1 text-xs text-sky-800">{{ dispatchProviderCaption() }}</p>
+      @if (dispatchRoutesThroughCodex()) {
+      <p
+        class="mt-2 text-xs font-medium text-sky-900"
+        data-og7-id="admin-ops-provider-routing-note"
+      >
+        The backend still routes execution through the Codex GitHub workflow; this selector lets you
+        switch the briefing, default model and quota cockpit quickly.
+      </p>
+      }
+    </div>
+
+    <div
+      class="mt-4 overflow-hidden rounded-[28px] border border-slate-800 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.16),_transparent_36%),linear-gradient(160deg,_#07111f_0%,_#091a2d_52%,_#050b15_100%)] p-4 text-white shadow-[0_22px_60px_rgba(2,6,23,0.38)]"
+      data-og7="admin-ops-ai-key-console"
+    >
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p class="text-[11px] font-semibold uppercase tracking-[0.3em] text-cyan-200/80">
+            Engine ignition console
+          </p>
+          <h3 class="mt-2 text-lg font-semibold text-white">Provider key sockets</h3>
+          <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+            Insert each engine key into the GitHub Actions console to light the corresponding
+            module. Missing keys keep the bay dark. Detected keys light the indicator green.
+          </p>
+        </div>
+        <div
+          class="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-cyan-100"
+        >
+          {{ liveTelemetryLabel() }} · {{ liveTelemetryDetail() }}
+        </div>
+      </div>
+
+      <ul class="mt-5 grid gap-3 lg:grid-cols-2">
+        @for (module of aiIgnitionModules(); track trackAiIgnitionModule($index, module)) {
+        <li
+          class="og7-ignition-module relative overflow-hidden rounded-[22px] border p-4 transition"
+          data-og7="admin-ops-ai-key-module"
+          [attr.data-og7-id]="'admin-ops-ai-key-' + module.provider"
+          [attr.data-og7-state]="module.state"
+          [attr.data-og7-selected]="isAiDiagnosticSelected(module)"
+          [style.animation-delay.ms]="aiIgnitionRevealDelay($index)"
+          [class.border-emerald-400/40]="isAiIgnitionReady(module)"
+          [class.bg-emerald-400/10]="isAiIgnitionReady(module)"
+          [class.shadow-[0_0_0_1px_rgba(74,222,128,0.08),0_0_28px_rgba(74,222,128,0.16)]]="isAiIgnitionReady(module)"
+          [class.ring-1]="isAiDiagnosticSelected(module)"
+          [class.ring-cyan-300/45]="isAiDiagnosticSelected(module)"
+          [class.border-slate-700]="isAiIgnitionOffline(module) || isAiIgnitionUnsupported(module)"
+          [class.bg-slate-950/55]="isAiIgnitionOffline(module) || isAiIgnitionUnsupported(module)"
+          [class.border-amber-400/40]="isAiIgnitionUnknown(module)"
+          [class.bg-amber-400/10]="isAiIgnitionUnknown(module)"
+        >
+          <div class="absolute inset-y-4 left-4 w-px bg-white/10"></div>
+          <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div class="flex items-center gap-4 pl-4">
+              <div
+                class="relative h-16 w-24 rounded-[20px] border border-white/10 bg-slate-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+              >
+                <div
+                  class="absolute left-4 top-1/2 h-[2px] w-8 -translate-y-1/2 rounded-full bg-slate-700"
+                ></div>
+                <div
+                  class="absolute right-3 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full border transition"
+                  [class.border-emerald-300/60]="isAiIgnitionReady(module)"
+                  [class.bg-emerald-300/10]="isAiIgnitionReady(module)"
+                  [class.shadow-[0_0_18px_rgba(74,222,128,0.35)]]="isAiIgnitionReady(module)"
+                  [class.border-slate-700]="!isAiIgnitionReady(module)"
+                  [class.bg-slate-900]="!isAiIgnitionReady(module)"
+                ></div>
+                @if (module.secretName) {
+                <svg
+                  viewBox="0 0 64 64"
+                  class="og7-ignition-key absolute left-1 top-1/2 h-12 w-12 -translate-y-1/2 transition"
+                  [class.og7-ignition-key--inserted]="module.keyInserted"
+                  [class.text-emerald-300]="isAiIgnitionReady(module)"
+                  [class.drop-shadow-[0_0_10px_rgba(74,222,128,0.45)]]="isAiIgnitionReady(module)"
+                  [class.text-slate-600]="!isAiIgnitionReady(module)"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="3.4"
+                  aria-hidden="true"
+                >
+                  <circle cx="20" cy="32" r="9"></circle>
+                  <path d="M29 32h18"></path>
+                  <path d="M41 32v7"></path>
+                  <path d="M47 32v4"></path>
+                </svg>
+                } @else {
+                <div
+                  class="absolute left-3 top-1/2 h-10 w-10 -translate-y-1/2 rounded-full border border-dashed border-slate-700"
+                ></div>
+                }
+              </div>
+
+              <div>
+                <div class="flex flex-wrap items-center gap-2">
+                  <p class="text-sm font-semibold text-white">{{ module.label }}</p>
+                  <span
+                    class="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-300"
+                  >
+                    {{ module.workflow }}
+                  </span>
+                </div>
+                <p class="mt-1 text-xs font-mono text-cyan-100/85">
+                  {{ module.secretName ?? 'No engine key exposed yet' }}
+                </p>
+                <p class="mt-2 max-w-md text-xs leading-5 text-slate-300">{{ module.note }}</p>
+                <button
+                  type="button"
+                  class="mt-3 inline-flex rounded-full border border-cyan-300/25 bg-cyan-400/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-cyan-100 transition hover:bg-cyan-400/16"
+                  [attr.data-og7-id]="'admin-ops-ai-key-inspect-' + module.provider"
+                  (click)="selectAiDiagnostic(module.provider)"
+                >
+                  Inspect bay
+                </button>
+              </div>
+            </div>
+
+            <div class="flex items-center gap-3 self-start md:self-center">
+              <div class="flex flex-col items-end gap-1 text-right">
+                <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Bay status
+                </span>
+                <span
+                  class="text-xs font-semibold"
+                  [class.text-emerald-200]="isAiIgnitionReady(module)"
+                  [class.text-amber-200]="isAiIgnitionUnknown(module)"
+                  [class.text-slate-300]="isAiIgnitionOffline(module) || isAiIgnitionUnsupported(module)"
+                >
+                  @if (isAiIgnitionReady(module)) { Ignition ready } @else if
+                  (isAiIgnitionUnknown(module)) { Scan link unavailable } @else if
+                  (isAiIgnitionUnsupported(module)) { Socket inactive } @else { Console offline }
+                </span>
+              </div>
+              <span
+                class="h-4 w-4 rounded-full border border-white/20 transition"
+                data-og7="admin-ops-ai-key-indicator"
+                [class.og7-ignition-indicator--ready]="isAiIgnitionReady(module)"
+                [class.og7-ignition-indicator--scan]="isAiIgnitionUnknown(module)"
+                [class.bg-emerald-400]="isAiIgnitionReady(module)"
+                [class.shadow-[0_0_18px_rgba(74,222,128,0.7)]]="isAiIgnitionReady(module)"
+                [class.bg-amber-400]="isAiIgnitionUnknown(module)"
+                [class.shadow-[0_0_18px_rgba(251,191,36,0.55)]]="isAiIgnitionUnknown(module)"
+                [class.bg-slate-700]="isAiIgnitionOffline(module) || isAiIgnitionUnsupported(module)"
+              ></span>
+            </div>
+          </div>
+        </li>
+        }
+      </ul>
+
+      @if (selectedAiDiagnosticModule(); as module) {
+      <section
+        class="mt-4 rounded-[24px] border border-white/10 bg-black/15 p-4"
+        data-og7="admin-ops-ai-diagnostics"
+        [attr.data-og7-id]="'admin-ops-ai-diagnostics-' + module.provider"
+      >
+        <div
+          class="flex flex-col gap-3 border-b border-white/10 pb-4 sm:flex-row sm:items-start sm:justify-between"
+        >
+          <div>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-200/80">
+              Operator diagnostics
+            </p>
+            <h4 class="mt-2 text-base font-semibold text-white">{{ module.label }} engine bay</h4>
+            <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-300">{{ module.note }}</p>
+          </div>
+          <span
+            class="inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold"
+            [class.border-emerald-300/25]="module.state === 'ready'"
+            [class.bg-emerald-400/10]="module.state === 'ready'"
+            [class.text-emerald-100]="module.state === 'ready'"
+            [class.border-amber-300/25]="module.state === 'scan-unavailable'"
+            [class.bg-amber-400/10]="module.state === 'scan-unavailable'"
+            [class.text-amber-100]="module.state === 'scan-unavailable'"
+            [class.border-slate-300/20]="module.state === 'unsupported' || module.state === 'offline'"
+            [class.bg-slate-900/70]="module.state === 'unsupported' || module.state === 'offline'"
+            [class.text-slate-100]="module.state === 'unsupported' || module.state === 'offline'"
+          >
+            State: {{ module.state }}
+          </span>
+        </div>
+
+        <div class="mt-4 grid gap-3 lg:grid-cols-2 xl:grid-cols-4">
+          @for (item of aiDiagnosticItems(); track item.id) {
+          <article
+            class="rounded-[18px] border p-3"
+            data-og7="admin-ops-ai-diagnostic-item"
+            [attr.data-og7-id]="item.id"
+            [class]="diagnosticToneClasses(item.tone)"
+          >
+            <p class="text-[10px] font-semibold uppercase tracking-[0.22em] opacity-80">
+              {{ item.label }}
+            </p>
+            <p class="mt-2 text-sm font-semibold">{{ item.value }}</p>
+          </article>
+          }
+        </div>
+
+        <div
+          class="mt-4 flex flex-col gap-2 rounded-[18px] border border-cyan-300/15 bg-cyan-400/8 px-4 py-3 text-sm text-cyan-50"
+        >
+          <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-cyan-200/80">
+            Recommended next action
+          </p>
+          <p data-og7-id="admin-ops-ai-diagnostic-action">{{ aiDiagnosticActionLabel() }}</p>
+        </div>
+      </section>
+      }
     </div>
 
     <div class="mt-4 grid gap-4 lg:grid-cols-[2fr_1fr]">
@@ -67,11 +315,26 @@
           data-og7-id="task"
           [value]="codexTask()"
           (input)="updateCodexTask($any($event.target).value)"
-          placeholder="Describe the exact change Codex should implement."
+          [placeholder]="'Describe the exact change ' + dispatchProviderLabel() + ' should implement.'"
         ></textarea>
       </label>
 
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm text-slate-700">
+          <span class="font-medium">AI provider</span>
+          <select
+            class="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-slate-500 focus:ring-2 focus:ring-slate-200"
+            data-og7="admin-ops-codex-field"
+            data-og7-id="provider"
+            [value]="dispatchProvider()"
+            (change)="updateDispatchProvider($any($event.target).value)"
+          >
+            @for (provider of dispatchProviders; track provider.id) {
+            <option [value]="provider.id">{{ provider.label }}</option>
+            }
+          </select>
+        </label>
+
         <label class="flex flex-col gap-2 text-sm text-slate-700">
           <span class="font-medium">Scope</span>
           <select
@@ -154,7 +417,8 @@
         (click)="dispatchCodexWorkflow()"
         [disabled]="!canDispatchCodex()"
       >
-        @if (codexSubmitting()) { Queueing Codex... } @else { Dispatch Codex workflow }
+        @if (codexSubmitting()) { Queueing {{ dispatchProviderLabel() }}... } @else { Dispatch {{
+        dispatchProviderLabel() }} request }
       </button>
     </div>
 
@@ -170,7 +434,9 @@
       class="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800"
       data-og7-id="admin-ops-codex-success"
     >
-      <p class="font-medium">Workflow queued on {{ result.owner }}/{{ result.repo }}.</p>
+      <p class="font-medium">
+        {{ dispatchProviderLabel() }} request queued on {{ result.owner }}/{{ result.repo }}.
+      </p>
       <p class="mt-1 text-xs text-emerald-700">
         Workflow {{ result.workflow }} on ref {{ result.ref }}. Requested at {{ result.requestedAt |
         date: 'yyyy-MM-dd HH:mm:ss' }}.

--- a/openg7-org/src/app/domains/admin/pages/admin-ops.page.spec.ts
+++ b/openg7-org/src/app/domains/admin/pages/admin-ops.page.spec.ts
@@ -85,6 +85,48 @@ class AdminOpsServiceMock {
         auth: {
           sessionIdleTimeoutMs: 3600000,
         },
+        aiKeys: [
+          {
+            provider: 'codex',
+            label: 'Codex',
+            workflow: 'codex-pr.yml',
+            secretName: 'OPENAI_API_KEY',
+            dispatchEnabled: true,
+            keyInserted: true,
+            state: 'ready',
+            note: 'Key detected. The engine bay is armed and ready for dispatch.',
+          },
+          {
+            provider: 'claude',
+            label: 'Claude',
+            workflow: 'claude-pr.yml',
+            secretName: 'ANTHROPIC_API_KEY',
+            dispatchEnabled: true,
+            keyInserted: false,
+            state: 'offline',
+            note: 'Insert ANTHROPIC_API_KEY into GitHub Actions secrets to power this module.',
+          },
+          {
+            provider: 'gemini',
+            label: 'Gemini',
+            workflow: 'gemini-pr.yml',
+            secretName: 'GEMINI_API_KEY',
+            dispatchEnabled: false,
+            keyInserted: false,
+            state: 'scan-unavailable',
+            note: 'The control plane could not verify GitHub Actions secrets for this module.',
+          },
+          {
+            provider: 'copilot',
+            label: 'GitHub Copilot',
+            workflow: 'copilot-pr.yml',
+            secretName: null,
+            dispatchEnabled: false,
+            keyInserted: false,
+            state: 'unsupported',
+            note: 'No stable ignition key is wired for this console yet.',
+          },
+        ],
         moderation: {
           pendingCompanies: 1,
           suspendedCompanies: 0,
@@ -99,12 +141,14 @@ class AdminOpsServiceMock {
       of<AdminOpsCodexDispatchResponse>({
         queued: true,
         provider: 'github-actions',
+        selectedProvider: payload.provider,
         owner: 'OpenG7',
         repo: 'openg7-platform',
         workflow: 'codex-pr.yml',
         ref: 'main',
         requestedAt: '2026-04-26T00:00:00.000Z',
         request: {
+          selectedProvider: payload.provider,
           scope: payload.scope,
           baseBranch: payload.baseBranch,
           draftPr: payload.draftPr,
@@ -119,16 +163,20 @@ class AdminOpsServiceMock {
 describe('AdminOpsPage', () => {
   let service: AdminOpsServiceMock;
   let notifications: jasmine.SpyObj<NotificationStoreApi>;
-  let routeQueryParams: Record<string, string>;
+  let activatedRouteMock: { snapshot: { queryParamMap: ReturnType<typeof convertToParamMap> } };
 
   beforeEach(async () => {
-    routeQueryParams = {};
     service = new AdminOpsServiceMock();
     notifications = jasmine.createSpyObj<NotificationStoreApi>('NotificationStoreApi', [
       'success',
       'info',
       'error',
     ]);
+    activatedRouteMock = {
+      snapshot: {
+        queryParamMap: convertToParamMap({}),
+      },
+    };
 
     await TestBed.configureTestingModule({
       imports: [AdminOpsPage],
@@ -137,13 +185,7 @@ describe('AdminOpsPage', () => {
         { provide: NotificationStore, useValue: notifications },
         {
           provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              get queryParamMap() {
-                return convertToParamMap(routeQueryParams);
-              },
-            },
-          },
+          useValue: activatedRouteMock,
         },
       ],
     }).compileComponents();
@@ -168,6 +210,7 @@ describe('AdminOpsPage', () => {
     fixture.detectChanges();
 
     expect(service.dispatchCodexWorkflow).toHaveBeenCalledWith({
+      provider: 'codex',
       task: 'Fix the login empty state and add a focused test.',
       scope: 'openg7-org',
       baseBranch: 'main',
@@ -180,7 +223,10 @@ describe('AdminOpsPage', () => {
   });
 
   it('prefills Codex dispatch fields from admin quality query params', () => {
-    Object.assign(routeQueryParams, {
+    activatedRouteMock.snapshot.queryParamMap = convertToParamMap({
+      aiProvider: 'copilot',
+      provider: 'copilot',
+      codexProvider: 'copilot',
       codexTask: 'Objectif: renforcer la preuve qualite.',
       codexScope: 'openg7-org',
       codexBaseBranch: 'release/quality',
@@ -208,12 +254,81 @@ describe('AdminOpsPage', () => {
     expect(
       (root.querySelector('[data-og7-id="draft-pr"]') as HTMLInputElement).checked,
     ).toBeFalse();
-    expect(notifications.info).toHaveBeenCalledWith(
-      'Codex dispatch prefilled from the quality cockpit.',
-      {
-        source: 'admin-ops',
-      },
+    expect(notifications.info).toHaveBeenCalled();
+  });
+
+  it('switches AI provider from the admin ops form and updates the helper state', () => {
+    const fixture = TestBed.createComponent(AdminOpsPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const providerField = root.querySelector('[data-og7-id="provider"]') as HTMLSelectElement;
+    const modelField = root.querySelector('[data-og7-id="model"]') as HTMLInputElement;
+
+    providerField.value = 'claude';
+    providerField.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.dispatchProvider()).toBe('claude');
+    expect(modelField.value).toBe('claude-sonnet-4-5');
+    expect(root.querySelector('[data-og7-id="admin-ops-provider-routing-note"]')).not.toBeNull();
+  });
+
+  it('renders the ignition console with green and dark key bays from the security snapshot', () => {
+    const fixture = TestBed.createComponent(AdminOpsPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const codexBay = root.querySelector('[data-og7-id="admin-ops-ai-key-codex"]');
+    const claudeBay = root.querySelector('[data-og7-id="admin-ops-ai-key-claude"]');
+    const geminiBay = root.querySelector('[data-og7-id="admin-ops-ai-key-gemini"]');
+    const readyIndicator = codexBay?.querySelector('[data-og7="admin-ops-ai-key-indicator"]');
+    const liveStatus = root.querySelector('[data-og7-id="admin-ops-live-status"]');
+    const liveDetail = root.querySelector('[data-og7-id="admin-ops-live-detail"]');
+
+    expect(root.querySelector('[data-og7="admin-ops-ai-key-console"]')).not.toBeNull();
+    expect(codexBay?.getAttribute('data-og7-state')).toBe('ready');
+    expect(claudeBay?.getAttribute('data-og7-state')).toBe('offline');
+    expect(geminiBay?.getAttribute('data-og7-state')).toBe('scan-unavailable');
+    expect(codexBay?.className).toContain('og7-ignition-module');
+    expect(codexBay?.getAttribute('style')).toContain('animation-delay');
+    expect(readyIndicator?.className).toContain('og7-ignition-indicator--ready');
+    expect(liveStatus?.textContent).toContain('Live pulse nominal');
+    expect(liveStatus?.getAttribute('data-og7-state')).toBe('live');
+    expect(liveDetail?.textContent).toContain('Next sweep in');
+    expect(root.textContent).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('shows provider diagnostics and updates the panel when another bay is inspected', () => {
+    const fixture = TestBed.createComponent(AdminOpsPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const claudeInspect = root.querySelector(
+      '[data-og7-id="admin-ops-ai-key-inspect-claude"]',
+    ) as HTMLButtonElement;
+
+    expect(root.querySelector('[data-og7="admin-ops-ai-diagnostics"]')?.textContent).toContain(
+      'Codex engine bay',
     );
+    expect(
+      root.querySelector('[data-og7-id="admin-ops-ai-diagnostic-action"]')?.textContent,
+    ).toContain('Run a dispatch');
+
+    claudeInspect.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.dispatchProvider()).toBe('claude');
+    expect(root.querySelector('[data-og7="admin-ops-ai-diagnostics"]')?.textContent).toContain(
+      'Claude engine bay',
+    );
+    expect(
+      root.querySelector('[data-og7="admin-ops-ai-diagnostic-item"][data-og7-id="socket"]')
+        ?.textContent,
+    ).toContain('ANTHROPIC_API_KEY');
+    expect(
+      root.querySelector('[data-og7-id="admin-ops-ai-diagnostic-action"]')?.textContent,
+    ).toContain('Insert ANTHROPIC_API_KEY');
   });
 
   it('shows the dispatch error inline when the backend rejects the request', () => {

--- a/openg7-org/src/app/domains/admin/pages/admin-ops.page.ts
+++ b/openg7-org/src/app/domains/admin/pages/admin-ops.page.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  NgZone,
   OnInit,
   computed,
   inject,
@@ -17,9 +18,15 @@ import { finalize } from 'rxjs';
 import {
   AdminOpsCodexDispatchResponse,
   AdminOpsCodexScope,
+  AdminOpsSecuritySnapshot,
   AdminOpsService,
   AdminOpsSnapshot,
 } from '../data-access/admin-ops.service';
+import {
+  ADMIN_AI_PROVIDER_OPTIONS,
+  AdminAiProvider,
+  resolveAdminAiProviderOption,
+} from '../data-access/admin-ai-providers';
 
 type AdminOpsProvenanceId = 'health' | 'backups' | 'imports' | 'security';
 
@@ -29,6 +36,15 @@ interface AdminOpsProvenanceEntry {
   readonly route: string;
   readonly generatedAt: string;
 }
+
+interface AdminOpsDiagnosticItem {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly tone: 'ready' | 'warning' | 'offline' | 'neutral';
+}
+
+type AdminOpsAiIgnitionModule = AdminOpsSecuritySnapshot['aiKeys'][number];
 
 const ADMIN_OPS_PROVENANCE_CONFIG: ReadonlyArray<{
   readonly id: AdminOpsProvenanceId;
@@ -50,25 +66,223 @@ const ADMIN_OPS_CODEX_SCOPES: readonly AdminOpsCodexScope[] = [
 ];
 
 const ADMIN_OPS_CODEX_EFFORTS = ['low', 'medium', 'high'] as const;
+const ADMIN_OPS_REFRESH_INTERVAL_MS = 30_000;
+const ADMIN_OPS_LIVE_TICK_INTERVAL_MS = 1_000;
 
 @Component({
   standalone: true,
   selector: 'og7-admin-ops-page',
   imports: [CommonModule],
   templateUrl: './admin-ops.page.html',
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .og7-ignition-module {
+        opacity: 0;
+        transform: translateY(12px) scale(0.985);
+        animation: og7-console-rise 620ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+      }
+
+      .og7-ignition-module::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          120deg,
+          transparent 0%,
+          rgba(255, 255, 255, 0.08) 48%,
+          transparent 100%
+        );
+        opacity: 0;
+        transform: translateX(-115%);
+        animation: og7-console-sheen 5.8s ease-in-out infinite;
+        pointer-events: none;
+      }
+
+      .og7-ignition-key {
+        transform-origin: 48px 32px;
+      }
+
+      .og7-ignition-key--inserted {
+        animation:
+          og7-key-seat 720ms cubic-bezier(0.2, 0.9, 0.2, 1) both,
+          og7-key-hum 3.6s ease-in-out 720ms infinite;
+      }
+
+      .og7-ignition-indicator--ready {
+        animation: og7-ready-pulse 2.4s ease-in-out infinite;
+      }
+
+      .og7-ignition-indicator--scan {
+        animation: og7-scan-pulse 2.8s linear infinite;
+      }
+
+      .og7-live-heartbeat {
+        animation: og7-live-heartbeat 1.8s ease-in-out infinite;
+      }
+
+      .og7-live-heartbeat--degraded {
+        animation: og7-live-degraded 2.4s ease-in-out infinite;
+      }
+
+      .og7-live-heartbeat--syncing {
+        animation: og7-live-syncing 1.2s linear infinite;
+      }
+
+      @keyframes og7-console-rise {
+        0% {
+          opacity: 0;
+          transform: translateY(12px) scale(0.985);
+        }
+
+        100% {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+
+      @keyframes og7-console-sheen {
+        0%,
+        22% {
+          opacity: 0;
+          transform: translateX(-115%);
+        }
+
+        30% {
+          opacity: 1;
+        }
+
+        44% {
+          opacity: 0;
+          transform: translateX(115%);
+        }
+
+        100% {
+          opacity: 0;
+          transform: translateX(115%);
+        }
+      }
+
+      @keyframes og7-key-seat {
+        0% {
+          transform: translateY(-50%) rotate(6deg) scale(0.92);
+        }
+
+        55% {
+          transform: translateY(-50%) rotate(-21deg) scale(1.02);
+        }
+
+        100% {
+          transform: translateY(-50%) rotate(-18deg) scale(1);
+        }
+      }
+
+      @keyframes og7-key-hum {
+        0%,
+        100% {
+          filter: brightness(1);
+        }
+
+        50% {
+          filter: brightness(1.12);
+        }
+      }
+
+      @keyframes og7-ready-pulse {
+        0%,
+        100% {
+          transform: scale(1);
+          box-shadow:
+            0 0 0 rgba(74, 222, 128, 0.18),
+            0 0 18px rgba(74, 222, 128, 0.42);
+        }
+
+        50% {
+          transform: scale(1.08);
+          box-shadow:
+            0 0 0 8px rgba(74, 222, 128, 0.08),
+            0 0 24px rgba(74, 222, 128, 0.7);
+        }
+      }
+
+      @keyframes og7-scan-pulse {
+        0%,
+        100% {
+          opacity: 0.82;
+          transform: scale(0.96);
+        }
+
+        50% {
+          opacity: 1;
+          transform: scale(1.08);
+        }
+      }
+
+      @keyframes og7-live-heartbeat {
+        0%,
+        100% {
+          transform: scale(1);
+          box-shadow: 0 0 0 rgba(34, 197, 94, 0.14);
+        }
+
+        50% {
+          transform: scale(1.1);
+          box-shadow: 0 0 0 8px rgba(34, 197, 94, 0.1);
+        }
+      }
+
+      @keyframes og7-live-degraded {
+        0%,
+        100% {
+          opacity: 0.72;
+          transform: scale(0.96);
+        }
+
+        50% {
+          opacity: 1;
+          transform: scale(1.06);
+        }
+      }
+
+      @keyframes og7-live-syncing {
+        0% {
+          transform: scale(0.9);
+          opacity: 0.55;
+        }
+
+        50% {
+          transform: scale(1.14);
+          opacity: 1;
+        }
+
+        100% {
+          transform: scale(0.9);
+          opacity: 0.55;
+        }
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AdminOpsPage implements OnInit {
   private readonly service = inject(AdminOpsService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly ngZone = inject(NgZone);
   private readonly notifications = injectNotificationStore();
   private readonly route = inject(ActivatedRoute);
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private liveTickTimer: ReturnType<typeof setInterval> | null = null;
 
   readonly loading = signal(true);
   readonly refreshing = signal(false);
   readonly error = signal<string | null>(null);
   readonly snapshot = signal<AdminOpsSnapshot | null>(null);
+  readonly liveNow = signal(Date.now());
+  readonly lastSuccessfulRefreshAt = signal<number | null>(null);
+  readonly dispatchProvider = signal<AdminAiProvider>('codex');
   readonly codexTask = signal('');
   readonly codexScope = signal<AdminOpsCodexScope>('openg7-org');
   readonly codexBaseBranch = signal('main');
@@ -78,8 +292,15 @@ export class AdminOpsPage implements OnInit {
   readonly codexSubmitting = signal(false);
   readonly codexError = signal<string | null>(null);
   readonly codexResult = signal<AdminOpsCodexDispatchResponse | null>(null);
+  readonly dispatchProviders = ADMIN_AI_PROVIDER_OPTIONS;
   readonly codexScopes = ADMIN_OPS_CODEX_SCOPES;
   readonly codexEfforts = ADMIN_OPS_CODEX_EFFORTS;
+  readonly dispatchProviderOption = computed(() =>
+    resolveAdminAiProviderOption(this.dispatchProvider()),
+  );
+  readonly dispatchProviderLabel = computed(() => this.dispatchProviderOption().label);
+  readonly dispatchProviderCaption = computed(() => this.dispatchProviderOption().caption);
+  readonly dispatchRoutesThroughCodex = computed(() => this.dispatchProvider() !== 'codex');
 
   readonly canDispatchCodex = computed(() => {
     return (
@@ -141,13 +362,140 @@ export class AdminOpsPage implements OnInit {
     return 'Each block lists the API source and snapshot timestamp currently displayed.';
   });
 
+  readonly aiIgnitionModules = computed<readonly AdminOpsAiIgnitionModule[]>(() => {
+    return this.snapshot()?.security.aiKeys ?? [];
+  });
+  readonly selectedAiDiagnosticModule = computed<AdminOpsAiIgnitionModule | null>(() => {
+    return (
+      this.aiIgnitionModules().find((module) => module.provider === this.dispatchProvider()) ?? null
+    );
+  });
+  readonly aiDiagnosticItems = computed<readonly AdminOpsDiagnosticItem[]>(() => {
+    const module = this.selectedAiDiagnosticModule();
+    if (!module) {
+      return [];
+    }
+
+    return [
+      {
+        id: 'workflow',
+        label: 'Workflow lane',
+        value: module.workflow,
+        tone: module.dispatchEnabled ? 'ready' : 'warning',
+      },
+      {
+        id: 'socket',
+        label: 'Secret socket',
+        value: module.secretName ?? 'No socket exposed',
+        tone: module.secretName ? 'neutral' : 'warning',
+      },
+      {
+        id: 'key',
+        label: 'Key insertion',
+        value: module.keyInserted ? 'Inserted and detected' : 'Missing from control plane',
+        tone: module.keyInserted ? 'ready' : 'offline',
+      },
+      {
+        id: 'dispatch',
+        label: 'Dispatch gate',
+        value: module.dispatchEnabled ? 'Enabled for operator launch' : 'Standby / disabled',
+        tone: module.dispatchEnabled ? 'ready' : 'warning',
+      },
+    ];
+  });
+  readonly aiDiagnosticActionLabel = computed(() => {
+    const module = this.selectedAiDiagnosticModule();
+    if (!module) {
+      return 'Diagnostics unavailable';
+    }
+    switch (module.state) {
+      case 'ready':
+        return 'Run a dispatch and review the returning PR/proof package.';
+      case 'scan-unavailable':
+        return 'Restore GitHub secret scanning before trusting this bay.';
+      case 'unsupported':
+        return 'Keep this provider in observation mode until a stable automation runner exists.';
+      default:
+        return module.secretName
+          ? `Insert ${module.secretName} and re-arm the workflow gate.`
+          : 'Finish wiring a secret socket and workflow before launch.';
+    }
+  });
+
+  readonly liveTelemetryState = computed<'live' | 'degraded' | 'syncing' | 'offline'>(() => {
+    if (this.loading() || this.refreshing()) {
+      return 'syncing';
+    }
+
+    if (!this.snapshot()) {
+      return 'offline';
+    }
+
+    const lastRefreshAt = this.lastSuccessfulRefreshAt();
+    if (lastRefreshAt == null) {
+      return this.error() ? 'degraded' : 'offline';
+    }
+
+    const ageMs = this.liveNow() - lastRefreshAt;
+    if (this.error() || ageMs > ADMIN_OPS_REFRESH_INTERVAL_MS * 2) {
+      return 'degraded';
+    }
+
+    return 'live';
+  });
+
+  readonly liveTelemetryLabel = computed(() => {
+    switch (this.liveTelemetryState()) {
+      case 'live':
+        return 'Live pulse nominal';
+      case 'degraded':
+        return 'Telemetry degraded';
+      case 'syncing':
+        return 'Sync in progress';
+      default:
+        return 'Console offline';
+    }
+  });
+
+  readonly liveTelemetryDetail = computed(() => {
+    const lastRefreshAt = this.lastSuccessfulRefreshAt();
+    if (this.liveTelemetryState() === 'offline') {
+      return 'Waiting for the first control-plane sync.';
+    }
+
+    if (this.liveTelemetryState() === 'syncing') {
+      return lastRefreshAt == null
+        ? 'Bootstrapping the cockpit feed.'
+        : `Last stable sync ${this.formatRelativeFromNow(lastRefreshAt)}.`;
+    }
+
+    const refreshCountdown = this.nextRefreshCountdownSeconds();
+    if (lastRefreshAt == null) {
+      return 'Awaiting refresh cadence.';
+    }
+
+    return `Last sync ${this.formatRelativeFromNow(lastRefreshAt)}. Next sweep in ${refreshCountdown}s.`;
+  });
+
   ngOnInit(): void {
     this.applyCodexRoutePrefill();
     this.fetchSnapshot(false);
-    this.refreshTimer = setInterval(() => this.fetchSnapshot(true), 60_000);
+    this.ngZone.runOutsideAngular(() => {
+      this.refreshTimer = setInterval(
+        () => this.ngZone.run(() => this.fetchSnapshot(true)),
+        ADMIN_OPS_REFRESH_INTERVAL_MS,
+      );
+      this.liveTickTimer = setInterval(
+        () => this.ngZone.run(() => this.liveNow.set(Date.now())),
+        ADMIN_OPS_LIVE_TICK_INTERVAL_MS,
+      );
+    });
     this.destroyRef.onDestroy(() => {
       if (this.refreshTimer) {
         clearInterval(this.refreshTimer);
+      }
+      if (this.liveTickTimer) {
+        clearInterval(this.liveTickTimer);
       }
     });
   }
@@ -159,6 +507,28 @@ export class AdminOpsPage implements OnInit {
   updateCodexTask(value: string): void {
     this.codexTask.set(value);
     this.codexError.set(null);
+  }
+
+  updateDispatchProvider(value: string): void {
+    const normalizedProvider = value.trim().toLowerCase();
+    if (!this.dispatchProviders.some((provider) => provider.id === normalizedProvider)) {
+      return;
+    }
+
+    const previousModel = resolveAdminAiProviderOption(this.dispatchProvider()).defaultModel;
+    const nextProvider = normalizedProvider as AdminAiProvider;
+    const nextOption = resolveAdminAiProviderOption(nextProvider);
+    const currentModel = this.codexModel().trim();
+
+    this.dispatchProvider.set(nextProvider);
+    if (!currentModel || currentModel === previousModel) {
+      this.codexModel.set(nextOption.defaultModel);
+    }
+    this.codexError.set(null);
+  }
+
+  selectAiDiagnostic(provider: AdminAiProvider): void {
+    this.updateDispatchProvider(provider);
   }
 
   updateCodexScope(value: string): void {
@@ -189,11 +559,13 @@ export class AdminOpsPage implements OnInit {
     const task = this.codexTask().trim();
     const baseBranch = this.codexBaseBranch().trim();
     if (!task) {
-      this.codexError.set('Describe the task you want to delegate before dispatching Codex.');
+      this.codexError.set(
+        'Describe the task you want to delegate before dispatching the selected AI.',
+      );
       return;
     }
     if (!baseBranch) {
-      this.codexError.set('Choose a target base branch before dispatching Codex.');
+      this.codexError.set('Choose a target base branch before dispatching the selected AI.');
       return;
     }
 
@@ -203,6 +575,7 @@ export class AdminOpsPage implements OnInit {
 
     this.service
       .dispatchCodexWorkflow({
+        provider: this.dispatchProvider(),
         task,
         scope: this.codexScope(),
         baseBranch,
@@ -220,7 +593,7 @@ export class AdminOpsPage implements OnInit {
         next: (result) => {
           this.codexResult.set(result);
           this.notifications.success(
-            'Codex workflow queued. Review the upcoming PR before merging.',
+            `${this.dispatchProviderLabel()} request queued. Review the upcoming PR before merging.`,
             {
               source: 'admin-ops',
             },
@@ -290,6 +663,60 @@ export class AdminOpsPage implements OnInit {
   trackImportEntry = (_: number, item: { id: string }) => item.id;
   trackSource = (_: number, item: { source: string }) => item.source;
   trackProvenanceEntry = (_: number, item: AdminOpsProvenanceEntry) => item.id;
+  trackAiIgnitionModule = (_: number, module: AdminOpsAiIgnitionModule) =>
+    `${module.provider}:${module.secretName ?? 'socket'}`;
+
+  aiIgnitionRevealDelay(index: number): number {
+    return 90 + index * 110;
+  }
+
+  isAiIgnitionReady(module: AdminOpsAiIgnitionModule): boolean {
+    return module.state === 'ready';
+  }
+
+  isAiIgnitionOffline(module: AdminOpsAiIgnitionModule): boolean {
+    return module.state === 'offline';
+  }
+
+  isAiIgnitionUnknown(module: AdminOpsAiIgnitionModule): boolean {
+    return module.state === 'scan-unavailable';
+  }
+
+  isAiIgnitionUnsupported(module: AdminOpsAiIgnitionModule): boolean {
+    return module.state === 'unsupported';
+  }
+
+  isAiDiagnosticSelected(module: AdminOpsAiIgnitionModule): boolean {
+    return this.selectedAiDiagnosticModule()?.provider === module.provider;
+  }
+
+  diagnosticToneClasses(tone: AdminOpsDiagnosticItem['tone']): string {
+    switch (tone) {
+      case 'ready':
+        return 'border-emerald-400/25 bg-emerald-400/10 text-emerald-100';
+      case 'warning':
+        return 'border-amber-400/25 bg-amber-400/10 text-amber-100';
+      case 'offline':
+        return 'border-rose-400/25 bg-rose-400/10 text-rose-100';
+      default:
+        return 'border-white/10 bg-white/5 text-slate-100';
+    }
+  }
+
+  isLiveTelemetry(state: 'live' | 'degraded' | 'syncing' | 'offline'): boolean {
+    return this.liveTelemetryState() === state;
+  }
+
+  nextRefreshCountdownSeconds(): number {
+    const lastRefreshAt = this.lastSuccessfulRefreshAt();
+    if (lastRefreshAt == null) {
+      return 0;
+    }
+
+    const elapsedMs = this.liveNow() - lastRefreshAt;
+    const remainingMs = Math.max(0, ADMIN_OPS_REFRESH_INTERVAL_MS - elapsedMs);
+    return Math.ceil(remainingMs / 1000);
+  }
 
   private fetchSnapshot(silent: boolean): void {
     if (silent) {
@@ -311,11 +738,29 @@ export class AdminOpsPage implements OnInit {
       .subscribe({
         next: (snapshot) => {
           this.snapshot.set(snapshot);
+          this.lastSuccessfulRefreshAt.set(Date.now());
         },
         error: (error: unknown) => {
           this.error.set(this.resolveError(error));
         },
       });
+  }
+
+  private formatRelativeFromNow(timestampMs: number): string {
+    const deltaMs = Math.max(0, this.liveNow() - timestampMs);
+    const seconds = Math.floor(deltaMs / 1000);
+    if (seconds < 5) {
+      return 'just now';
+    }
+    if (seconds < 60) {
+      return `${seconds}s ago`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes}m ago`;
+    }
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ago`;
   }
 
   private resolveError(error: unknown): string {
@@ -359,6 +804,8 @@ export class AdminOpsPage implements OnInit {
 
   private applyCodexRoutePrefill(): void {
     const params = this.route.snapshot.queryParamMap;
+    const provider =
+      params.get('aiProvider') ?? params.get('provider') ?? params.get('codexProvider');
     const task = params.get('codexTask') ?? params.get('task');
     const scope = params.get('codexScope') ?? params.get('scope');
     const baseBranch = params.get('codexBaseBranch') ?? params.get('baseBranch');
@@ -366,6 +813,13 @@ export class AdminOpsPage implements OnInit {
     const model = params.get('codexModel') ?? params.get('model');
     const effort = params.get('codexEffort') ?? params.get('effort');
 
+    const normalizedProvider = provider?.trim().toLowerCase() ?? null;
+    if (
+      normalizedProvider &&
+      this.dispatchProviders.some((candidate) => candidate.id === normalizedProvider)
+    ) {
+      this.dispatchProvider.set(normalizedProvider as AdminAiProvider);
+    }
     if (task?.trim()) {
       this.codexTask.set(task);
     }
@@ -380,15 +834,25 @@ export class AdminOpsPage implements OnInit {
     }
     if (model != null) {
       this.codexModel.set(model);
+    } else if (
+      normalizedProvider &&
+      this.dispatchProviders.some((candidate) => candidate.id === normalizedProvider)
+    ) {
+      this.codexModel.set(
+        resolveAdminAiProviderOption(normalizedProvider as AdminAiProvider).defaultModel,
+      );
     }
     if (effort != null) {
       this.codexEffort.set(effort);
     }
 
     if (task?.trim() || params.get('codexSource') === 'admin-quality') {
-      this.notifications.info('Codex dispatch prefilled from the quality cockpit.', {
-        source: 'admin-ops',
-      });
+      this.notifications.info(
+        `${this.dispatchProviderLabel()} dispatch prefilled from the quality cockpit.`,
+        {
+          source: 'admin-ops',
+        },
+      );
     }
   }
 }

--- a/openg7-org/src/app/domains/admin/pages/admin-ops.page.ts
+++ b/openg7-org/src/app/domains/admin/pages/admin-ops.page.ts
@@ -16,17 +16,17 @@ import { injectNotificationStore } from '@app/core/observability/notification.st
 import { finalize } from 'rxjs';
 
 import {
+  ADMIN_AI_PROVIDER_OPTIONS,
+  AdminAiProvider,
+  resolveAdminAiProviderOption,
+} from '../data-access/admin-ai-providers';
+import {
   AdminOpsCodexDispatchResponse,
   AdminOpsCodexScope,
   AdminOpsSecuritySnapshot,
   AdminOpsService,
   AdminOpsSnapshot,
 } from '../data-access/admin-ops.service';
-import {
-  ADMIN_AI_PROVIDER_OPTIONS,
-  AdminAiProvider,
-  resolveAdminAiProviderOption,
-} from '../data-access/admin-ai-providers';
 
 type AdminOpsProvenanceId = 'health' | 'backups' | 'imports' | 'security';
 

--- a/openg7-org/src/app/domains/admin/pages/admin-quality-mission-control.component.html
+++ b/openg7-org/src/app/domains/admin/pages/admin-quality-mission-control.component.html
@@ -2,11 +2,17 @@
   class="relative w-full overflow-hidden rounded-[30px] border border-sky-500/25 bg-[#040d1d]/96 p-4 text-slate-100 shadow-[0_36px_110px_-58px_rgba(14,165,233,0.72)] sm:p-5"
   data-og7="admin-quality-mission-control"
 >
-  <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.2),_transparent_34%),radial-gradient(circle_at_88%_14%,_rgba(168,85,247,0.14),_transparent_22%),linear-gradient(180deg,_rgba(2,6,23,0.24),_rgba(2,6,23,0.04))]"></div>
-  <div class="pointer-events-none absolute -right-8 top-24 h-40 w-40 rounded-full bg-sky-400/10 blur-3xl"></div>
+  <div
+    class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.2),_transparent_34%),radial-gradient(circle_at_88%_14%,_rgba(168,85,247,0.14),_transparent_22%),linear-gradient(180deg,_rgba(2,6,23,0.24),_rgba(2,6,23,0.04))]"
+  ></div>
+  <div
+    class="pointer-events-none absolute -right-8 top-24 h-40 w-40 rounded-full bg-sky-400/10 blur-3xl"
+  ></div>
 
   <div class="relative space-y-4">
-    <div class="flex flex-col gap-3 border-b border-white/10 pb-4 xl:flex-row xl:items-start xl:justify-between">
+    <div
+      class="flex flex-col gap-3 border-b border-white/10 pb-4 xl:flex-row xl:items-start xl:justify-between"
+    >
       <div class="space-y-2">
         <div class="flex items-center gap-3">
           <span
@@ -17,8 +23,12 @@
           </span>
 
           <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-300">Pilotage AI</p>
-            <h2 class="mt-1 text-[1.9rem] font-semibold tracking-tight text-white">AI Mission Control</h2>
+            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-300">
+              Pilotage AI
+            </p>
+            <h2 class="mt-1 text-[1.9rem] font-semibold tracking-tight text-white">
+              AI Mission Control
+            </h2>
           </div>
         </div>
 
@@ -35,6 +45,12 @@
           Phase : {{ missionControl().phaseLabel }}
         </span>
         <span
+          class="inline-flex rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1.5 text-[11px] font-semibold text-cyan-100"
+          data-og7-id="admin-quality-active-ai-provider"
+        >
+          AI : {{ selectedAiProviderLabel() }}
+        </span>
+        <span
           class="inline-flex rounded-full border border-amber-400/25 bg-amber-400/10 px-3 py-1.5 text-[11px] font-semibold text-amber-100"
         >
           Cue : {{ missionCueLabel() }}
@@ -42,7 +58,371 @@
       </div>
     </div>
 
+    <article
+      class="og7-flight-bay rounded-3xl border border-cyan-400/20 bg-[linear-gradient(145deg,rgba(7,20,38,0.96),rgba(4,14,30,0.92))] p-4 shadow-[0_28px_70px_-48px_rgba(56,189,248,0.58)]"
+      data-og7="admin-quality-ai-bay"
+      [attr.data-og7-state]="providerFlightDeckState()"
+    >
+      <div class="pointer-events-none absolute inset-y-5 left-5 w-px bg-white/10"></div>
+      <div class="relative grid gap-4 xl:grid-cols-[minmax(0,1fr)_12rem] xl:items-center">
+        <div class="flex items-center gap-4 pl-4">
+          <div
+            class="relative h-16 w-24 rounded-[20px] border border-white/10 bg-slate-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          >
+            <div
+              class="absolute left-4 top-1/2 h-0.5 w-8 -translate-y-1/2 rounded-full bg-slate-700"
+            ></div>
+            <div
+              class="absolute right-3 top-1/2 h-9 w-9 -translate-y-1/2 rounded-full border border-cyan-300/45 bg-cyan-400/10"
+            ></div>
+            <svg
+              viewBox="0 0 64 64"
+              class="og7-flight-key absolute left-1 top-1/2 h-12 w-12 -translate-y-1/2 text-cyan-200 drop-shadow-[0_0_10px_rgba(56,189,248,0.35)]"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="3.4"
+              aria-hidden="true"
+            >
+              <circle cx="20" cy="32" r="9"></circle>
+              <path d="M29 32h18"></path>
+              <path d="M41 32v7"></path>
+              <path d="M47 32v4"></path>
+            </svg>
+          </div>
+
+          <div class="space-y-2">
+            <div class="flex flex-wrap items-center gap-2">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.26em] text-cyan-200/80">
+                Flight deck
+              </p>
+              <span
+                class="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="providerFlightDeckStatusClasses()"
+                data-og7-id="admin-quality-ai-bay-status"
+              >
+                {{ providerFlightDeckLabel() }}
+              </span>
+              <span
+                class="inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="aiTelemetryClasses()"
+                data-og7-id="admin-quality-ai-telemetry-status"
+                [attr.data-og7-state]="aiTelemetryState()"
+              >
+                <span
+                  class="h-2.5 w-2.5 rounded-full"
+                  [class.og7-flight-telemetry--live]="aiTelemetryState() === 'live'"
+                  [class.og7-flight-telemetry--degraded]="aiTelemetryState() === 'degraded'"
+                  [class.og7-flight-telemetry--syncing]="aiTelemetryState() === 'syncing'"
+                  [class.bg-emerald-400]="aiTelemetryState() === 'live'"
+                  [class.bg-amber-400]="aiTelemetryState() === 'degraded'"
+                  [class.bg-sky-400]="aiTelemetryState() === 'syncing'"
+                  [class.bg-slate-400]="aiTelemetryState() === 'offline'"
+                ></span>
+                {{ aiTelemetryLabel() }}
+              </span>
+            </div>
+            <h3 class="text-lg font-semibold text-white">
+              {{ selectedAiProviderLabel() }} console
+            </h3>
+            <p class="max-w-xl text-sm leading-6 text-slate-300">
+              {{ selectedAiProviderCaption() }}
+            </p>
+            <p class="max-w-xl text-xs leading-5 text-cyan-100/80">
+              {{ providerFlightDeckNote() }}
+            </p>
+            <p
+              class="max-w-xl text-[11px] leading-5 text-slate-400"
+              data-og7-id="admin-quality-ai-telemetry-detail"
+            >
+              {{ aiTelemetryDetail() }}
+            </p>
+          </div>
+        </div>
+
+        <div
+          class="flex items-center justify-between gap-3 rounded-[20px] border border-white/10 bg-white/4 px-4 py-3 xl:flex-col xl:items-end xl:text-right"
+        >
+          <div>
+            <p class="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+              {{ providerFlightDeckMetricLabel() }}
+            </p>
+            <p class="mt-2 text-3xl font-semibold" [class]="providerFlightDeckMetricClasses()">
+              {{ providerFlightDeckMetric() }}
+            </p>
+          </div>
+          <span
+            class="h-4 w-4 rounded-full border border-white/20 bg-cyan-400 shadow-[0_0_18px_rgba(56,189,248,0.55)]"
+            [class.og7-flight-indicator--armed]="providerFlightDeckState() === 'armed'"
+            [class.bg-amber-400]="providerFlightDeckState() === 'constrained'"
+            [class.shadow-[0_0_18px_rgba(251,191,36,0.48)]]="
+              providerFlightDeckState() === 'constrained'
+            "
+            [class.bg-cyan-400]="providerFlightDeckState() === 'armed'"
+          ></span>
+        </div>
+      </div>
+    </article>
+
+    <section
+      class="rounded-3xl border border-white/10 bg-[#071426]/90 p-4"
+      data-og7="admin-quality-provider-comparison"
+    >
+      <div
+        class="flex flex-col gap-2 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between"
+      >
+        <div>
+          <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-200/80">
+            Provider comparison
+          </p>
+          <h3 class="mt-2 text-base font-semibold text-white">Dispatch lanes at a glance</h3>
+          <p class="mt-2 text-sm text-slate-300">
+            Compare key readiness, workflow lane, and last proof telemetry before switching console.
+          </p>
+        </div>
+        <span
+          class="inline-flex rounded-full border border-white/10 bg-white/4 px-3 py-1 text-xs text-slate-200"
+        >
+          {{ providerComparison().length }} providers tracked
+        </span>
+      </div>
+
+      <div class="mt-4 grid gap-3 xl:grid-cols-4">
+        @for (entry of providerComparison(); track entry.provider) {
+          <article
+            class="rounded-[20px] border p-4"
+            data-og7="admin-quality-provider-comparison-card"
+            [attr.data-og7-id]="entry.provider"
+            [attr.data-og7-selected]="entry.selected"
+            [attr.data-og7-proof-state]="entry.proofState"
+            [class]="providerComparisonCardClasses(entry)"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-sm font-semibold text-white">{{ entry.label }}</p>
+                <p class="mt-1 text-[11px] uppercase tracking-[0.2em] text-slate-400">
+                  {{ entry.workflow }}
+                </p>
+              </div>
+              <span
+                class="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="providerComparisonOpsClasses(entry.opsState)"
+              >
+                {{ entry.opsLabel }}
+              </span>
+            </div>
+
+            <p class="mt-3 text-xs leading-5 text-slate-300">{{ entry.opsDetail }}</p>
+
+            <div class="mt-4 flex flex-wrap gap-2 text-[11px] font-semibold">
+              <span
+                class="inline-flex rounded-full border px-2.5 py-1"
+                [class]="missionProofStateClasses(entry.proofState)"
+              >
+                {{ entry.proofLabel }}
+              </span>
+              <span
+                class="inline-flex rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-slate-200"
+              >
+                {{ entry.artifactCount }} artifact(s)
+              </span>
+            </div>
+
+            <p class="mt-3 text-xs leading-5 text-slate-300">{{ entry.proofDetail }}</p>
+            <p class="mt-2 text-[11px] text-slate-400">{{ entry.pullRequestLabel }}</p>
+          </article>
+        }
+      </div>
+    </section>
+
     @if (selectedMission(); as missionItem) {
+      <section
+        class="rounded-[22px] border border-white/10 bg-[#071426]/90 p-4"
+        data-og7="admin-quality-mission-loop"
+      >
+        <div
+          class="flex flex-col gap-3 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between"
+        >
+          <div>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-200/80">
+              Mission loop
+            </p>
+            <h3 class="mt-2 text-base font-semibold text-white">
+              Mission -> dispatch -> proof -> validation
+            </h3>
+            <p class="mt-2 text-sm text-slate-300">
+              Unified operator view for {{ selectedAiProviderLabel() }} through
+              {{ aiDispatchWorkflow() }}.
+            </p>
+          </div>
+
+          <span
+            class="inline-flex rounded-full border border-white/10 bg-white/4 px-3 py-1.5 text-xs font-medium text-slate-200"
+            data-og7-id="admin-quality-mission-loop-summary"
+          >
+            {{ missionStatusLabel(missionItem.status) }}
+          </span>
+        </div>
+
+        <div class="mt-4 grid gap-3 xl:grid-cols-4">
+          @for (step of missionExecutionLoop(); track step.id) {
+            <article
+              class="rounded-[20px] border p-4"
+              data-og7="admin-quality-mission-loop-step"
+              [attr.data-og7-id]="step.id"
+              [attr.data-og7-status]="step.status"
+              [class]="missionLoopCardClasses(step.status)"
+            >
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.22em] opacity-80">
+                    {{ step.label }}
+                  </p>
+                  <p class="mt-2 text-sm font-semibold text-white">{{ step.detail }}</p>
+                </div>
+                <span
+                  class="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                  [class]="missionLoopBadgeClasses(step.status)"
+                >
+                  {{ missionLoopStatusLabel(step.status) }}
+                </span>
+              </div>
+              <p class="mt-3 text-xs leading-5 text-slate-300">{{ step.support }}</p>
+            </article>
+          }
+        </div>
+
+        <section
+          class="mt-4 rounded-[20px] border border-cyan-300/12 bg-slate-950/45 px-4 py-3"
+          data-og7="admin-quality-mission-energy-lane"
+        >
+          <div
+            class="grid grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)_auto_minmax(0,1fr)_auto] items-center gap-2"
+          >
+            @for (step of missionExecutionLoop(); track step.id; let index = $index) {
+              <div class="flex flex-col items-center gap-1 text-center">
+                <span
+                  class="inline-flex h-10 w-10 items-center justify-center rounded-full border text-[10px] font-semibold uppercase tracking-[0.18em]"
+                  data-og7="admin-quality-mission-energy-node"
+                  [attr.data-og7-id]="step.id"
+                  [attr.data-og7-status]="step.status"
+                  [class]="missionEnergyLaneNodeClasses(step.status)"
+                >
+                  {{ index + 1 }}
+                </span>
+                <span class="text-[9px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  {{ step.label }}
+                </span>
+              </div>
+
+              @if (index < missionEnergyLaneSegments().length) {
+                @let segment = missionEnergyLaneSegments()[index];
+                <div
+                  class="flex flex-col gap-1"
+                  data-og7="admin-quality-mission-energy-lane-segment"
+                  [attr.data-og7-id]="segment.id"
+                  [attr.data-og7-state]="segment.state"
+                >
+                  <div
+                    class="relative h-3 overflow-hidden rounded-full border"
+                    [class]="missionEnergyLaneTrackClasses(segment.state)"
+                  >
+                    <span
+                      [class]="missionEnergyLaneBeamClasses(segment.state)"
+                      [style.animation-delay.ms]="segment.delayMs"
+                    ></span>
+                  </div>
+                  <p
+                    class="text-center text-[9px] font-semibold uppercase tracking-[0.18em] text-slate-500"
+                  >
+                    {{ missionEnergyLaneStateLabel(segment.state) }}
+                  </p>
+                </div>
+              }
+            }
+          </div>
+        </section>
+
+        @if (selectedAiProof(); as proof) {
+          <article
+            class="mt-4 rounded-[20px] border border-white/10 bg-slate-950/55 p-4"
+            data-og7="admin-quality-proof-telemetry"
+            [attr.data-og7-state]="proof.state"
+          >
+            <div
+              class="flex flex-col gap-3 border-b border-white/10 pb-4 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div>
+                <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-cyan-200/80">
+                  Live proof telemetry
+                </p>
+                <h4 class="mt-2 text-base font-semibold text-white">{{ proof.label }}</h4>
+                <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-300">{{ proof.summary }}</p>
+              </div>
+              <span
+                class="inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold"
+                [class]="missionProofStateClasses(proof.state)"
+              >
+                {{ proof.label }}
+              </span>
+            </div>
+
+            <div class="mt-4 grid gap-3 lg:grid-cols-3">
+              <article class="rounded-[18px] border border-white/10 bg-white/4 p-3">
+                <p class="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Last run
+                </p>
+                <p class="mt-2 text-sm font-semibold text-white">{{ proof.runLabel }}</p>
+                <p class="mt-2 text-xs leading-5 text-slate-300">{{ proof.detail }}</p>
+                @if (proof.runUrl) {
+                  <a
+                    class="mt-3 inline-flex text-xs font-semibold text-cyan-200 underline-offset-4 hover:underline"
+                    [href]="proof.runUrl"
+                    target="_blank"
+                    rel="noreferrer"
+                    data-og7-id="admin-quality-proof-run-link"
+                  >
+                    Open workflow run
+                  </a>
+                }
+              </article>
+
+              <article class="rounded-[18px] border border-white/10 bg-white/4 p-3">
+                <p class="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Artifacts
+                </p>
+                <p class="mt-2 text-sm font-semibold text-white">{{ proof.artifactLabel }}</p>
+                <p class="mt-2 text-xs leading-5 text-slate-300">
+                  Screenshots, logs, and proof bundles observed on the latest provider run.
+                </p>
+              </article>
+
+              <article class="rounded-[18px] border border-white/10 bg-white/4 p-3">
+                <p class="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Pull request
+                </p>
+                <p class="mt-2 text-sm font-semibold text-white">{{ proof.pullRequestLabel }}</p>
+                <p class="mt-2 text-xs leading-5 text-slate-300">
+                  Proof review can pivot directly into the opened branch lane when a PR exists.
+                </p>
+                @if (proof.pullRequestUrl) {
+                  <a
+                    class="mt-3 inline-flex text-xs font-semibold text-cyan-200 underline-offset-4 hover:underline"
+                    [href]="proof.pullRequestUrl"
+                    target="_blank"
+                    rel="noreferrer"
+                    data-og7-id="admin-quality-proof-pr-link"
+                  >
+                    Open pull request
+                  </a>
+                }
+              </article>
+            </div>
+          </article>
+        }
+      </section>
+
       <article
         class="rounded-[24px] border border-white/10 bg-[#071426]/90 p-4 shadow-[0_30px_80px_-50px_rgba(8,47,73,0.95)]"
         data-og7="admin-quality-mission-hero"
@@ -53,8 +433,12 @@
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div>
                   <p class="text-sm font-semibold text-emerald-300">Mission active</p>
-                  <h3 class="mt-2 text-[1.8rem] font-semibold leading-tight text-white">{{ missionItem.title }}</h3>
-                  <p class="mt-1 text-sm text-slate-100">Type : {{ recommendationKindLabel(missionItem) }}</p>
+                  <h3 class="mt-2 text-[1.8rem] font-semibold leading-tight text-white">
+                    {{ missionItem.title }}
+                  </h3>
+                  <p class="mt-1 text-sm text-slate-100">
+                    Type : {{ recommendationKindLabel(missionItem) }}
+                  </p>
                 </div>
 
                 <span
@@ -74,7 +458,9 @@
 
               <article class="rounded-[18px] border border-emerald-500/20 bg-emerald-500/10 p-4">
                 <p class="text-sm font-semibold text-emerald-200">Mission suggeree</p>
-                <p class="mt-2 text-sm leading-relaxed text-emerald-50/95">{{ missionItem.summary }}</p>
+                <p class="mt-2 text-sm leading-relaxed text-emerald-50/95">
+                  {{ missionItem.summary }}
+                </p>
               </article>
             </div>
 
@@ -87,32 +473,38 @@
                   [attr.aria-disabled]="isMissionActionBlocked(action.action, missionItem)"
                   [attr.title]="
                     isMissionActionBlocked(action.action, missionItem)
-                      ? ('admin.quality.codex.notifications.insufficientQuota' | translate : {
-                          required: selectedMissionQuotaSummary()?.requiredUnits ?? 0,
-                          available: selectedMissionQuotaSummary()?.availableUnits ?? 0,
-                          missing: selectedMissionQuotaSummary()?.shortageUnits ?? 0
-                        })
+                      ? aiDispatchStatusDetail()
                       : null
                   "
                   (click)="emitMissionAction(action.action, missionItem)"
                   data-og7="action"
                   [attr.data-og7-id]="action.hookId ?? null"
                 >
-                  {{ action.label }}
+                  {{
+                    action.action === 'auto-delegate'
+                      ? aiDispatching()
+                        ? 'Dispatch...'
+                        : 'Lancer ' + selectedAiProviderLabel()
+                      : action.label
+                  }}
                 </button>
               }
             </div>
           </div>
 
           <div class="rounded-[22px] border border-white/10 bg-white/[0.04] px-4 py-4 text-center">
-            <p class="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">Confiance AI</p>
+            <p class="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+              Confiance AI
+            </p>
             <div
               class="relative mx-auto mt-4 flex h-20 w-20 items-center justify-center rounded-full shadow-[0_20px_40px_-28px_rgba(14,165,233,0.8)]"
               [style.background]="confidenceRingBackground(missionItem.confidence)"
             >
               <div class="absolute inset-[6px] rounded-full bg-[#071120]"></div>
               <div class="relative">
-                <p class="text-lg font-semibold text-white">{{ confidencePercent(missionItem.confidence) }}%</p>
+                <p class="text-lg font-semibold text-white">
+                  {{ confidencePercent(missionItem.confidence) }}%
+                </p>
               </div>
             </div>
             <span
@@ -142,26 +534,37 @@
             <div class="flex flex-wrap items-start justify-between gap-3">
               <div>
                 <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-200/80">
-                  {{ 'admin.quality.codex.runway.label' | translate }}
+                  {{
+                    'admin.quality.codex.runway.label'
+                      | translate: { provider: selectedAiProviderLabel() }
+                  }}
                 </p>
                 <h3 class="mt-2 text-lg font-semibold text-white">
-                  {{ 'admin.quality.codex.runway.title' | translate }}
+                  {{
+                    'admin.quality.codex.runway.title'
+                      | translate: { provider: selectedAiProviderLabel() }
+                  }}
                 </h3>
                 <p class="mt-2 text-sm leading-relaxed text-slate-300">
-                  {{ 'admin.quality.codex.runway.subtitle' | translate }}
+                  {{
+                    'admin.quality.codex.runway.subtitle'
+                      | translate: { provider: selectedAiProviderLabel() }
+                  }}
+                </p>
+                <p class="mt-2 text-xs leading-relaxed text-cyan-100/80">
+                  {{ selectedAiProviderCaption() }}
                 </p>
               </div>
 
               <span
                 class="inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold"
-                [class]="quotaStatusClasses(quota.sufficient)"
+                [class]="quotaStatusClasses(aiDispatchReady())"
                 data-og7-id="admin-quality-codex-quota-status"
               >
                 {{
-                  (
-                    quota.sufficient
-                      ? 'admin.quality.codex.runway.status.sufficient'
-                      : 'admin.quality.codex.runway.status.insufficient'
+                  (aiDispatchReady()
+                    ? 'admin.quality.codex.runway.status.sufficient'
+                    : 'admin.quality.codex.runway.status.insufficient'
                   ) | translate
                 }}
               </span>
@@ -172,7 +575,10 @@
                 <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
                   {{ 'admin.quality.codex.runway.metrics.tasks' | translate }}
                 </p>
-                <p class="mt-2 text-2xl font-semibold text-white" data-og7-id="admin-quality-generated-task-count">
+                <p
+                  class="mt-2 text-2xl font-semibold text-white"
+                  data-og7-id="admin-quality-generated-task-count"
+                >
                   {{ quota.taskCount }}
                 </p>
                 <p class="mt-1 text-xs text-slate-400">
@@ -196,42 +602,37 @@
                 <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
                   {{ 'admin.quality.codex.runway.metrics.available' | translate }}
                 </p>
-                <label class="mt-2 block">
-                  <span class="sr-only">{{ 'admin.quality.codex.runway.metrics.available' | translate }}</span>
-                  <input
-                    type="number"
-                    min="0"
-                    step="1"
-                    class="w-full rounded-[14px] border border-white/10 bg-slate-950/80 px-3 py-2 text-sm text-white outline-none"
-                    [value]="availableCodexQuotaUnits()"
-                    (input)="availableCodexQuotaUnitsChanged.emit($event)"
-                    data-og7-id="admin-quality-codex-quota-input"
-                  />
-                </label>
-                <p class="mt-1 text-xs text-slate-400">
-                  {{ 'admin.quality.codex.runway.metrics.availableBody' | translate }}
+                <p
+                  class="mt-2 text-lg font-semibold text-white"
+                  data-og7-id="admin-quality-codex-ops-status"
+                >
+                  {{ aiDispatchStatusLabel() }}
+                </p>
+                <p class="mt-1 text-xs leading-relaxed text-slate-400">
+                  {{
+                    'admin.quality.codex.runway.metrics.availableBody'
+                      | translate: { provider: selectedAiProviderLabel() }
+                  }}
                 </p>
               </article>
 
               <article class="rounded-[18px] border border-white/10 bg-white/[0.04] p-3">
                 <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
                   {{
-                    (
-                      quota.sufficient
-                        ? 'admin.quality.codex.runway.metrics.remaining'
-                        : 'admin.quality.codex.runway.metrics.missing'
+                    (aiDispatchReady()
+                      ? 'admin.quality.codex.runway.metrics.remaining'
+                      : 'admin.quality.codex.runway.metrics.missing'
                     ) | translate
                   }}
                 </p>
-                <p class="mt-2 text-2xl font-semibold text-white">
-                  {{ quota.sufficient ? quota.remainingUnits : quota.shortageUnits }}
+                <p class="mt-2 break-all text-lg font-semibold text-white">
+                  {{ aiDispatchWorkflow() }}
                 </p>
-                <p class="mt-1 text-xs text-slate-400">
+                <p class="mt-1 text-xs leading-relaxed text-slate-400">
                   {{
-                    (
-                      quota.sufficient
-                        ? 'admin.quality.codex.runway.metrics.remainingBody'
-                        : 'admin.quality.codex.runway.metrics.missingBody'
+                    (aiDispatchReady()
+                      ? 'admin.quality.codex.runway.metrics.remainingBody'
+                      : 'admin.quality.codex.runway.metrics.missingBody'
                     ) | translate
                   }}
                 </p>
@@ -240,11 +641,10 @@
 
             <p class="mt-4 text-sm text-slate-300">
               {{
-                (
-                  quota.sufficient
-                    ? 'admin.quality.codex.runway.ready'
-                    : 'admin.quality.codex.runway.blocked'
-                ) | translate
+                (aiDispatchReady()
+                  ? 'admin.quality.codex.runway.ready'
+                  : 'admin.quality.codex.runway.blocked'
+                ) | translate: { provider: selectedAiProviderLabel() }
               }}
             </p>
           </article>
@@ -253,17 +653,24 @@
             class="rounded-[24px] border border-white/10 bg-[#071426]/90 p-4 shadow-[0_28px_72px_-48px_rgba(15,23,42,0.9)]"
             data-og7="admin-quality-generated-tasks"
           >
-            <div class="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 pb-4">
+            <div
+              class="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 pb-4"
+            >
               <div>
                 <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-violet-200/80">
                   {{ 'admin.quality.codex.tasks.label' | translate }}
                 </p>
                 <h3 class="mt-2 text-lg font-semibold text-white">
-                  {{ 'admin.quality.codex.tasks.title' | translate: { count: selectedMissionTasks().length } }}
+                  {{
+                    'admin.quality.codex.tasks.title'
+                      | translate: { count: selectedMissionTasks().length }
+                  }}
                 </h3>
               </div>
 
-              <span class="inline-flex rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-semibold text-slate-200">
+              <span
+                class="inline-flex rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-semibold text-slate-200"
+              >
                 {{ missionItem.title }}
               </span>
             </div>
@@ -278,21 +685,35 @@
                   <div class="flex flex-wrap items-start justify-between gap-3">
                     <div class="min-w-0">
                       <div class="flex flex-wrap items-center gap-2">
-                        <span class="inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold" [class]="taskKindClasses(task.kind)">
+                        <span
+                          class="inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold"
+                          [class]="taskKindClasses(task.kind)"
+                        >
                           {{ taskKindKey(task.kind) | translate }}
                         </span>
                         @if (task.blocking) {
-                          <span class="inline-flex rounded-full border border-amber-400/25 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100">
+                          <span
+                            class="inline-flex rounded-full border border-amber-400/25 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100"
+                          >
                             {{ 'admin.quality.codex.tasks.blocking' | translate }}
                           </span>
                         }
                       </div>
-                      <p class="mt-3 text-sm font-semibold text-white break-all">{{ task.headline }}</p>
-                      <p class="mt-1 text-xs leading-relaxed text-slate-400 break-all">{{ task.support }}</p>
+                      <p class="mt-3 text-sm font-semibold text-white break-all">
+                        {{ task.headline }}
+                      </p>
+                      <p class="mt-1 text-xs leading-relaxed text-slate-400 break-all">
+                        {{ task.support }}
+                      </p>
                     </div>
 
-                    <span class="inline-flex rounded-full border border-white/10 bg-slate-950/80 px-2.5 py-1 text-[11px] font-semibold text-slate-100">
-                      {{ 'admin.quality.codex.tasks.units' | translate: { count: task.estimatedUnits } }}
+                    <span
+                      class="inline-flex rounded-full border border-white/10 bg-slate-950/80 px-2.5 py-1 text-[11px] font-semibold text-slate-100"
+                    >
+                      {{
+                        'admin.quality.codex.tasks.units'
+                          | translate: { count: task.estimatedUnits }
+                      }}
                     </span>
                   </div>
                 </article>
@@ -303,23 +724,37 @@
       }
     }
 
-    <section class="rounded-[22px] border border-white/10 bg-[#071426]/90 p-4" data-og7-id="admin-quality-mission-timeline">
-      <div class="flex flex-col gap-3 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+    <section
+      class="rounded-[22px] border border-white/10 bg-[#071426]/90 p-4"
+      data-og7-id="admin-quality-mission-timeline"
+    >
+      <div
+        class="flex flex-col gap-3 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between"
+      >
         <div>
-          <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-sky-300">Timeline de la mission</p>
+          <p class="text-[11px] font-semibold uppercase tracking-[0.28em] text-sky-300">
+            Timeline de la mission
+          </p>
           <h3 class="mt-2 text-base font-semibold text-white">
             {{ activeTimelineStep()?.label ?? missionControl().phaseLabel }}
           </h3>
         </div>
 
-        <span class="inline-flex rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-slate-200">
+        <span
+          class="inline-flex rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-slate-200"
+        >
           {{ selectedDomain() ?? 'Aucun domaine actif' }}
         </span>
       </div>
 
       <div class="mt-5 hidden md:flex items-start">
         @for (step of missionTimelineSteps(); track step.id) {
-          <div class="flex min-w-0 flex-1 items-start" data-og7="admin-quality-mission-step" [attr.data-og7-id]="step.id" [attr.data-og7-status]="step.status">
+          <div
+            class="flex min-w-0 flex-1 items-start"
+            data-og7="admin-quality-mission-step"
+            [attr.data-og7-id]="step.id"
+            [attr.data-og7-status]="step.status"
+          >
             <div class="flex flex-1 flex-col items-center text-center">
               <span
                 class="relative z-10 flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold"
@@ -327,14 +762,20 @@
               >
                 {{ missionTimelineMarkerText(step.status, $index) }}
               </span>
-              <p class="mt-3 text-sm font-semibold" [ngClass]="step.status === 'pending' ? 'text-slate-400' : 'text-white'">
+              <p
+                class="mt-3 text-sm font-semibold"
+                [ngClass]="step.status === 'pending' ? 'text-slate-400' : 'text-white'"
+              >
                 {{ step.shortLabel }}
               </p>
               <p class="mt-1 text-xs text-slate-400">{{ step.label }}</p>
             </div>
 
             @if (!$last) {
-              <span class="mt-4 block h-px flex-1" [class]="missionTimelineConnectorClasses(step.status)"></span>
+              <span
+                class="mt-4 block h-px flex-1"
+                [class]="missionTimelineConnectorClasses(step.status)"
+              ></span>
             }
           </div>
         }
@@ -342,7 +783,12 @@
 
       <div class="mt-4 space-y-3 md:hidden">
         @for (step of missionTimelineSteps(); track step.id) {
-          <article class="flex gap-3" data-og7="admin-quality-mission-step" [attr.data-og7-id]="step.id" [attr.data-og7-status]="step.status">
+          <article
+            class="flex gap-3"
+            data-og7="admin-quality-mission-step"
+            [attr.data-og7-id]="step.id"
+            [attr.data-og7-status]="step.status"
+          >
             <div class="flex w-9 shrink-0 flex-col items-center">
               <span
                 class="flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold"
@@ -351,13 +797,21 @@
                 {{ missionTimelineMarkerText(step.status, $index) }}
               </span>
               @if (!$last) {
-                <span class="mt-2 w-px flex-1" [class]="missionTimelineVerticalConnectorClasses(step.status)"></span>
+                <span
+                  class="mt-2 w-px flex-1"
+                  [class]="missionTimelineVerticalConnectorClasses(step.status)"
+                ></span>
               }
             </div>
 
-            <div class="min-w-0 flex-1 rounded-[18px] border p-3" [class]="missionTimelineCardClasses(step.status)">
+            <div
+              class="min-w-0 flex-1 rounded-[18px] border p-3"
+              [class]="missionTimelineCardClasses(step.status)"
+            >
               <p class="text-sm font-semibold text-white">{{ step.label }}</p>
-              <p class="mt-1 text-xs text-slate-300">{{ missionTimelineStatusLabel(step.status) }}</p>
+              <p class="mt-1 text-xs text-slate-300">
+                {{ missionTimelineStatusLabel(step.status) }}
+              </p>
             </div>
           </article>
         }
@@ -391,20 +845,31 @@
                   <h3 class="text-base font-semibold text-white">{{ recommendation.title }}</h3>
                 </div>
 
-                <span class="inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold" [class]="missionStatusClasses(recommendation.status)">
+                <span
+                  class="inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold"
+                  [class]="missionStatusClasses(recommendation.status)"
+                >
                   {{ missionStatusLabel(recommendation.status) }}
                 </span>
               </div>
 
-              <p class="mt-3 text-sm leading-relaxed text-slate-200">{{ recommendation.summary }}</p>
+              <p class="mt-3 text-sm leading-relaxed text-slate-200">
+                {{ recommendation.summary }}
+              </p>
               <p class="mt-3 text-xs leading-relaxed text-slate-400">{{ recommendation.whyNow }}</p>
             </button>
 
             <div class="mt-4 flex flex-wrap gap-2 text-[11px] font-semibold">
-              <span class="inline-flex rounded-full border px-2.5 py-1" [class]="confidenceClasses(recommendation.confidence)">
+              <span
+                class="inline-flex rounded-full border px-2.5 py-1"
+                [class]="confidenceClasses(recommendation.confidence)"
+              >
                 Confiance {{ recommendation.confidence }}
               </span>
-              <span class="inline-flex rounded-full border px-2.5 py-1" [class]="impactClasses(recommendation.impact)">
+              <span
+                class="inline-flex rounded-full border px-2.5 py-1"
+                [class]="impactClasses(recommendation.impact)"
+              >
                 Impact {{ recommendation.impact }}
               </span>
             </div>
@@ -420,7 +885,13 @@
                   data-og7="action"
                   [attr.data-og7-id]="action.hookId ?? null"
                 >
-                  {{ action.label }}
+                  {{
+                    action.action === 'auto-delegate'
+                      ? aiDispatching()
+                        ? 'Dispatch...'
+                        : 'Lancer ' + selectedAiProviderLabel()
+                      : action.label
+                  }}
                 </button>
               }
             </div>
@@ -433,7 +904,9 @@
           class="rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(8,19,40,0.96),rgba(4,11,27,0.98))] p-5"
           data-og7="admin-quality-mission-detail"
         >
-          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Mission selectionnee</p>
+          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+            Mission selectionnee
+          </p>
           <h3 class="mt-2 text-lg font-semibold text-white">{{ missionItem.title }}</h3>
           <p class="mt-2 text-sm text-slate-300">{{ missionItem.whyNow }}</p>
         </article>
@@ -445,14 +918,19 @@
       >
         <div class="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
           @for (step of workflowSteps(); track step.id) {
-            <article class="rounded-[20px] border p-4 transition" [class]="workflowCardClasses(step.active)">
+            <article
+              class="rounded-[20px] border p-4 transition"
+              [class]="workflowCardClasses(step.active)"
+            >
               <div
                 class="flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold"
                 [class]="workflowBadgeClasses(step.accent, step.active)"
               >
                 {{ $index + 1 }}
               </div>
-              <p class="mt-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{{ step.label }}</p>
+              <p class="mt-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+                {{ step.label }}
+              </p>
               <p class="mt-2 text-sm font-semibold text-white">{{ step.headline }}</p>
               <p class="mt-1 text-xs leading-relaxed text-slate-300">{{ step.detail }}</p>
             </article>

--- a/openg7-org/src/app/domains/admin/pages/admin-quality-mission-control.component.ts
+++ b/openg7-org/src/app/domains/admin/pages/admin-quality-mission-control.component.ts
@@ -19,7 +19,47 @@ import {
   AdminQualityMissionStatus,
   AdminQualityMissionTimelineStatus,
 } from './admin-quality-mission-control';
-import { AdminQualityMissionQuotaSummary, AdminQualityMissionTask, AdminQualityMissionTaskKind } from './admin-quality-mission-task-planner';
+import {
+  AdminQualityMissionQuotaSummary,
+  AdminQualityMissionTask,
+  AdminQualityMissionTaskKind,
+} from './admin-quality-mission-task-planner';
+
+type AdminQualityMissionTelemetryState = 'live' | 'degraded' | 'syncing' | 'offline';
+type AdminQualityMissionProofState =
+  | 'queued'
+  | 'in-progress'
+  | 'completed'
+  | 'failed'
+  | 'unavailable';
+
+export interface AdminQualityMissionProofDisplay {
+  readonly state: AdminQualityMissionProofState;
+  readonly label: string;
+  readonly summary: string;
+  readonly detail: string;
+  readonly artifactCount: number;
+  readonly artifactLabel: string;
+  readonly runLabel: string;
+  readonly runUrl: string | null;
+  readonly pullRequestLabel: string;
+  readonly pullRequestUrl: string | null;
+}
+
+export interface AdminQualityMissionProviderComparisonEntry {
+  readonly provider: string;
+  readonly label: string;
+  readonly selected: boolean;
+  readonly opsState: 'armed' | 'constrained' | 'unsupported';
+  readonly opsLabel: string;
+  readonly opsDetail: string;
+  readonly workflow: string;
+  readonly proofState: AdminQualityMissionProofState;
+  readonly proofLabel: string;
+  readonly proofDetail: string;
+  readonly artifactCount: number;
+  readonly pullRequestLabel: string;
+}
 
 interface AdminQualityMissionWorkflowStep {
   readonly id: string;
@@ -39,11 +79,238 @@ interface AdminQualityMissionTimelineStepView {
   readonly status: AdminQualityMissionTimelineStatus;
 }
 
+interface AdminQualityMissionExecutionLoopStep {
+  readonly id: string;
+  readonly label: string;
+  readonly detail: string;
+  readonly support: string;
+  readonly status: 'done' | 'current' | 'pending' | 'blocked';
+}
+
+interface AdminQualityMissionEnergyLaneSegment {
+  readonly id: string;
+  readonly fromLabel: string;
+  readonly toLabel: string;
+  readonly state: 'charged' | 'flowing' | 'standby' | 'fault';
+  readonly delayMs: number;
+}
+
 @Component({
   selector: 'og7-admin-quality-mission-control',
   standalone: true,
   imports: [CommonModule, TranslateModule],
   templateUrl: './admin-quality-mission-control.component.html',
+  styles: [
+    `
+      :host {
+        width: 100%;
+      }
+
+      .og7-flight-bay {
+        position: relative;
+        overflow: hidden;
+      }
+
+      .og7-flight-bay::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          115deg,
+          transparent 0%,
+          rgba(125, 211, 252, 0.08) 46%,
+          transparent 100%
+        );
+        opacity: 0;
+        transform: translateX(-110%);
+        animation: og7-flight-sheen 6.4s ease-in-out infinite;
+        pointer-events: none;
+      }
+
+      .og7-flight-key {
+        transform-origin: 48px 32px;
+        animation: og7-flight-key 720ms cubic-bezier(0.2, 0.9, 0.2, 1) both;
+      }
+
+      .og7-flight-indicator--armed {
+        animation: og7-flight-pulse 2.5s ease-in-out infinite;
+      }
+
+      .og7-flight-telemetry--live {
+        animation: og7-flight-pulse 2.2s ease-in-out infinite;
+      }
+
+      .og7-flight-telemetry--degraded {
+        animation: og7-flight-degraded 2.6s ease-in-out infinite;
+      }
+
+      .og7-flight-telemetry--syncing {
+        animation: og7-flight-sync 1.2s linear infinite;
+      }
+
+      .og7-mission-energy-beam {
+        position: absolute;
+        inset: 0;
+        border-radius: 9999px;
+      }
+
+      .og7-mission-energy-beam--flowing {
+        background: linear-gradient(
+          90deg,
+          rgba(34, 211, 238, 0.06) 0%,
+          rgba(56, 189, 248, 0.92) 42%,
+          rgba(34, 211, 238, 0.06) 100%
+        );
+        background-size: 220% 100%;
+        animation: og7-mission-energy-flow 2.4s linear infinite;
+      }
+
+      .og7-mission-energy-beam--charged {
+        background: linear-gradient(
+          90deg,
+          rgba(16, 185, 129, 0.2) 0%,
+          rgba(52, 211, 153, 0.8) 100%
+        );
+        animation: og7-mission-energy-hum 2.8s ease-in-out infinite;
+      }
+
+      .og7-mission-energy-beam--fault {
+        background: linear-gradient(
+          90deg,
+          rgba(251, 113, 133, 0.18) 0%,
+          rgba(244, 63, 94, 0.82) 100%
+        );
+        animation: og7-mission-energy-fault 1.5s ease-in-out infinite;
+      }
+
+      @keyframes og7-flight-sheen {
+        0%,
+        24% {
+          opacity: 0;
+          transform: translateX(-110%);
+        }
+
+        32% {
+          opacity: 1;
+        }
+
+        46% {
+          opacity: 0;
+          transform: translateX(110%);
+        }
+
+        100% {
+          opacity: 0;
+          transform: translateX(110%);
+        }
+      }
+
+      @keyframes og7-flight-key {
+        0% {
+          transform: translateY(-50%) rotate(10deg) scale(0.92);
+        }
+
+        55% {
+          transform: translateY(-50%) rotate(-16deg) scale(1.02);
+        }
+
+        100% {
+          transform: translateY(-50%) rotate(-12deg) scale(1);
+        }
+      }
+
+      @keyframes og7-flight-pulse {
+        0%,
+        100% {
+          transform: scale(1);
+          box-shadow:
+            0 0 0 rgba(56, 189, 248, 0.12),
+            0 0 18px rgba(56, 189, 248, 0.36);
+        }
+
+        50% {
+          transform: scale(1.08);
+          box-shadow:
+            0 0 0 8px rgba(56, 189, 248, 0.08),
+            0 0 24px rgba(56, 189, 248, 0.52);
+        }
+      }
+
+      @keyframes og7-flight-degraded {
+        0%,
+        100% {
+          opacity: 0.72;
+          transform: scale(0.96);
+        }
+
+        50% {
+          opacity: 1;
+          transform: scale(1.06);
+        }
+      }
+
+      @keyframes og7-flight-sync {
+        0% {
+          transform: scale(0.9);
+          opacity: 0.55;
+        }
+
+        50% {
+          transform: scale(1.14);
+          opacity: 1;
+        }
+
+        100% {
+          transform: scale(0.9);
+          opacity: 0.55;
+        }
+      }
+
+      @keyframes og7-mission-energy-flow {
+        0% {
+          background-position: 200% 0;
+          opacity: 0.4;
+        }
+
+        50% {
+          opacity: 1;
+        }
+
+        100% {
+          background-position: -40% 0;
+          opacity: 0.45;
+        }
+      }
+
+      @keyframes og7-mission-energy-hum {
+        0%,
+        100% {
+          opacity: 0.65;
+          filter: saturate(0.9);
+        }
+
+        50% {
+          opacity: 1;
+          filter: saturate(1.18);
+        }
+      }
+
+      @keyframes og7-mission-energy-fault {
+        0%,
+        100% {
+          opacity: 0.55;
+        }
+
+        45% {
+          opacity: 1;
+        }
+
+        60% {
+          opacity: 0.35;
+        }
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AdminQualityMissionControlComponent {
@@ -57,12 +324,22 @@ export class AdminQualityMissionControlComponent {
   readonly selectedMissionTasks = input<readonly AdminQualityMissionTask[]>([]);
   readonly selectedMissionQuotaSummary = input<AdminQualityMissionQuotaSummary | null>(null);
   readonly canStartSelectedMission = input(false);
-  readonly availableCodexQuotaUnits = input(0);
+  readonly selectedAiProviderLabel = input('Codex');
+  readonly selectedAiProviderCaption = input('');
+  readonly aiDispatchReady = input(false);
+  readonly aiDispatchStatusLabel = input('Ops indisponible');
+  readonly aiDispatchStatusDetail = input('');
+  readonly aiDispatchWorkflow = input('workflow non detecte');
+  readonly aiTelemetryState = input<AdminQualityMissionTelemetryState>('offline');
+  readonly aiTelemetryLabel = input('Console offline');
+  readonly aiTelemetryDetail = input('Waiting for Ops telemetry feed.');
+  readonly aiDispatching = input(false);
+  readonly selectedAiProof = input<AdminQualityMissionProofDisplay | null>(null);
+  readonly providerComparison = input<readonly AdminQualityMissionProviderComparisonEntry[]>([]);
   readonly speaking = input(false);
 
   readonly missionSelected = output<AdminQualityMissionRecommendation>();
   readonly missionAction = output<AdminQualityMissionControlActionEvent>();
-  readonly availableCodexQuotaUnitsChanged = output<Event>();
   readonly speakRequested = output<void>();
   readonly stopSpeakingRequested = output<void>();
 
@@ -103,7 +380,9 @@ export class AdminQualityMissionControlComponent {
       id: 'proof',
       label: 'Preuve',
       headline: this.selectedMission()?.title ?? 'Aucune',
-      detail: this.selectedMission() ? this.missionStatusLabel(this.selectedMission()!.status) : 'Attente',
+      detail: this.selectedMission()
+        ? this.missionStatusLabel(this.selectedMission()!.status)
+        : 'Attente',
       accent: 'indigo',
       active: Boolean(this.selectedMission()),
     },
@@ -117,7 +396,7 @@ export class AdminQualityMissionControlComponent {
       supportLabel: this.timelineSupportLabel(step.id, step.label),
       helper: this.timelineHelper(step.id, step.label),
       status: step.status,
-    }))
+    })),
   );
 
   readonly missionTimelineProgress = computed(() => {
@@ -137,6 +416,152 @@ export class AdminQualityMissionControlComponent {
     const steps = this.missionTimelineSteps();
     const index = this.activeTimelineIndex(steps);
     return steps[index] ?? null;
+  });
+  readonly missionExecutionLoop = computed<readonly AdminQualityMissionExecutionLoopStep[]>(() => {
+    const mission = this.selectedMission();
+    const status = mission?.status ?? 'proposed';
+    const dispatchReady = this.aiDispatchReady();
+    const dispatching = this.aiDispatching();
+    const workflow = this.aiDispatchWorkflow();
+    const proof = this.selectedAiProof();
+
+    const missionStepStatus: AdminQualityMissionExecutionLoopStep['status'] =
+      status === 'blocked' || status === 'rejected'
+        ? 'blocked'
+        : status === 'proposed'
+          ? 'current'
+          : 'done';
+
+    const dispatchStepStatus: AdminQualityMissionExecutionLoopStep['status'] = dispatching
+      ? 'current'
+      : ['in-progress', 'proof-returned', 'done'].includes(status)
+        ? 'done'
+        : dispatchReady
+          ? 'pending'
+          : 'blocked';
+
+    const proofStepStatus: AdminQualityMissionExecutionLoopStep['status'] =
+      status === 'done'
+        ? 'done'
+        : status === 'proof-returned'
+          ? 'current'
+          : status === 'blocked'
+            ? 'blocked'
+            : 'pending';
+
+    const validationStepStatus: AdminQualityMissionExecutionLoopStep['status'] =
+      status === 'done'
+        ? 'done'
+        : status === 'proof-returned'
+          ? 'current'
+          : status === 'rejected'
+            ? 'blocked'
+            : 'pending';
+
+    return [
+      {
+        id: 'mission',
+        label: 'Mission lock',
+        detail:
+          status === 'proposed'
+            ? 'Awaiting operator approval.'
+            : `Mission ${this.missionStatusLabel(status)}.`,
+        support: mission?.title ?? 'No mission selected.',
+        status: missionStepStatus,
+      },
+      {
+        id: 'dispatch',
+        label: 'Dispatch lane',
+        detail: dispatching
+          ? `Dispatch in progress through ${workflow}.`
+          : dispatchStepStatus === 'done'
+            ? `${workflow} has been queued for this mission.`
+            : dispatchReady
+              ? `Runway armed on ${workflow}.`
+              : this.aiDispatchStatusLabel(),
+        support: this.aiDispatchStatusDetail(),
+        status: dispatchStepStatus,
+      },
+      {
+        id: 'proof',
+        label: 'Proof return',
+        detail:
+          status === 'proof-returned'
+            ? 'Proof package is back for QA review.'
+            : status === 'done'
+              ? 'Proof accepted and archived.'
+              : 'Waiting for evidence, tests and artefacts to return.',
+        support: proof?.summary ?? 'Tests, screenshots, logs and PR evidence converge here.',
+        status: proofStepStatus,
+      },
+      {
+        id: 'validation',
+        label: 'Final sign-off',
+        detail:
+          status === 'done'
+            ? 'Final validation completed.'
+            : status === 'proof-returned'
+              ? 'Review proof and close the loop.'
+              : 'Matrix update and closure remain pending.',
+        support: 'Once validated, the mission can update coverage and leave the active queue.',
+        status: validationStepStatus,
+      },
+    ];
+  });
+  readonly missionEnergyLaneSegments = computed<readonly AdminQualityMissionEnergyLaneSegment[]>(
+    () => {
+      const steps = this.missionExecutionLoop();
+      const segments: AdminQualityMissionEnergyLaneSegment[] = [];
+
+      for (let index = 0; index < steps.length - 1; index += 1) {
+        const fromStep = steps[index];
+        const toStep = steps[index + 1];
+        if (!fromStep || !toStep) {
+          continue;
+        }
+
+        segments.push({
+          id: `${fromStep.id}-${toStep.id}`,
+          fromLabel: fromStep.label,
+          toLabel: toStep.label,
+          state: this.resolveMissionEnergyLaneState(fromStep.status, toStep.status),
+          delayMs: index * 180,
+        });
+      }
+
+      return segments;
+    },
+  );
+
+  readonly providerFlightDeckState = computed<'armed' | 'constrained'>(() => {
+    return this.aiDispatchReady() ? 'armed' : 'constrained';
+  });
+
+  readonly providerFlightDeckLabel = computed(() => {
+    return this.providerFlightDeckState() === 'armed' ? 'Ops armed' : 'Ops constrained';
+  });
+
+  readonly providerFlightDeckNote = computed(() => {
+    const quota = this.selectedMissionQuotaSummary();
+    const detail = this.aiDispatchStatusDetail();
+    if (quota && this.aiDispatchReady()) {
+      return `${this.selectedAiProviderLabel()} is cleared by Ops for this mission plan. ${detail}`;
+    }
+
+    return detail || `Verify live engine keys in Ops before dispatch.`;
+  });
+
+  readonly providerFlightDeckMetric = computed(() => {
+    const quota = this.selectedMissionQuotaSummary();
+    return quota?.requiredUnits ?? 0;
+  });
+
+  readonly providerFlightDeckMetricLabel = computed(() => {
+    return 'Estimated units';
+  });
+
+  readonly providerFlightDeckMetricTone = computed<'ready' | 'warning'>(() => {
+    return this.providerFlightDeckState() === 'armed' ? 'ready' : 'warning';
   });
 
   isMissionSelected(recommendation: AdminQualityMissionRecommendation): boolean {
@@ -169,6 +594,187 @@ export class AdminQualityMissionControlComponent {
       default:
         return 'border-violet-400/25 bg-violet-400/10 text-violet-100';
     }
+  }
+
+  providerFlightDeckStatusClasses(): string {
+    return this.providerFlightDeckState() === 'armed'
+      ? 'border-cyan-400/25 bg-cyan-400/10 text-cyan-100'
+      : 'border-amber-400/25 bg-amber-400/10 text-amber-100';
+  }
+
+  providerFlightDeckMetricClasses(): string {
+    return this.providerFlightDeckMetricTone() === 'ready' ? 'text-cyan-100' : 'text-amber-100';
+  }
+
+  aiTelemetryClasses(): string {
+    switch (this.aiTelemetryState()) {
+      case 'live':
+        return 'border-emerald-400/25 bg-emerald-400/10 text-emerald-100';
+      case 'degraded':
+        return 'border-amber-400/25 bg-amber-400/10 text-amber-100';
+      case 'syncing':
+        return 'border-sky-400/25 bg-sky-400/10 text-sky-100';
+      default:
+        return 'border-white/12 bg-white/5 text-slate-200';
+    }
+  }
+
+  missionLoopCardClasses(status: AdminQualityMissionExecutionLoopStep['status']): string {
+    switch (status) {
+      case 'done':
+        return 'border-emerald-400/25 bg-emerald-400/10 text-emerald-50';
+      case 'current':
+        return 'border-sky-400/30 bg-sky-400/12 text-white shadow-[0_24px_60px_-40px_rgba(56,189,248,0.55)]';
+      case 'blocked':
+        return 'border-rose-400/25 bg-rose-400/10 text-rose-50';
+      default:
+        return 'border-white/10 bg-white/4 text-slate-200';
+    }
+  }
+
+  missionLoopBadgeClasses(status: AdminQualityMissionExecutionLoopStep['status']): string {
+    switch (status) {
+      case 'done':
+        return 'border-emerald-300/35 bg-emerald-400/18 text-emerald-50';
+      case 'current':
+        return 'border-sky-300/45 bg-sky-400/20 text-sky-50';
+      case 'blocked':
+        return 'border-rose-300/35 bg-rose-400/18 text-rose-50';
+      default:
+        return 'border-white/10 bg-white/5 text-slate-300';
+    }
+  }
+
+  missionLoopStatusLabel(status: AdminQualityMissionExecutionLoopStep['status']): string {
+    switch (status) {
+      case 'done':
+        return 'Done';
+      case 'current':
+        return 'Current';
+      case 'blocked':
+        return 'Blocked';
+      default:
+        return 'Pending';
+    }
+  }
+
+  missionEnergyLaneTrackClasses(state: AdminQualityMissionEnergyLaneSegment['state']): string {
+    switch (state) {
+      case 'charged':
+        return 'border-emerald-300/18 bg-emerald-400/12';
+      case 'flowing':
+        return 'border-sky-300/20 bg-sky-400/12';
+      case 'fault':
+        return 'border-rose-300/18 bg-rose-400/12';
+      default:
+        return 'border-white/10 bg-white/5';
+    }
+  }
+
+  missionEnergyLaneBeamClasses(state: AdminQualityMissionEnergyLaneSegment['state']): string {
+    switch (state) {
+      case 'charged':
+        return 'og7-mission-energy-beam og7-mission-energy-beam--charged';
+      case 'flowing':
+        return 'og7-mission-energy-beam og7-mission-energy-beam--flowing';
+      case 'fault':
+        return 'og7-mission-energy-beam og7-mission-energy-beam--fault';
+      default:
+        return 'og7-mission-energy-beam opacity-0';
+    }
+  }
+
+  missionEnergyLaneNodeClasses(status: AdminQualityMissionExecutionLoopStep['status']): string {
+    switch (status) {
+      case 'done':
+        return 'border-emerald-300/35 bg-emerald-400/18 text-emerald-50 shadow-[0_0_18px_rgba(52,211,153,0.22)]';
+      case 'current':
+        return 'border-sky-300/45 bg-sky-400/20 text-sky-50 shadow-[0_0_24px_rgba(56,189,248,0.28)]';
+      case 'blocked':
+        return 'border-rose-300/35 bg-rose-400/18 text-rose-50 shadow-[0_0_18px_rgba(244,63,94,0.18)]';
+      default:
+        return 'border-white/10 bg-slate-900/85 text-slate-300';
+    }
+  }
+
+  missionEnergyLaneStateLabel(state: AdminQualityMissionEnergyLaneSegment['state']): string {
+    switch (state) {
+      case 'charged':
+        return 'charged';
+      case 'flowing':
+        return 'flowing';
+      case 'fault':
+        return 'fault';
+      default:
+        return 'standby';
+    }
+  }
+
+  missionProofStateClasses(state: AdminQualityMissionProofState): string {
+    switch (state) {
+      case 'completed':
+        return 'border-emerald-400/25 bg-emerald-400/10 text-emerald-100';
+      case 'in-progress':
+        return 'border-sky-400/25 bg-sky-400/10 text-sky-100';
+      case 'queued':
+        return 'border-amber-400/25 bg-amber-400/10 text-amber-100';
+      case 'failed':
+        return 'border-rose-400/25 bg-rose-400/10 text-rose-100';
+      default:
+        return 'border-white/10 bg-white/5 text-slate-200';
+    }
+  }
+
+  providerComparisonCardClasses(entry: AdminQualityMissionProviderComparisonEntry): string {
+    if (entry.selected) {
+      return 'border-cyan-300/35 bg-cyan-400/10 shadow-[0_24px_60px_-42px_rgba(34,211,238,0.35)]';
+    }
+
+    if (entry.opsState === 'armed') {
+      return 'border-emerald-400/18 bg-emerald-400/8';
+    }
+
+    if (entry.opsState === 'unsupported') {
+      return 'border-slate-400/18 bg-slate-900/70';
+    }
+
+    return 'border-amber-400/18 bg-amber-400/8';
+  }
+
+  providerComparisonOpsClasses(
+    state: AdminQualityMissionProviderComparisonEntry['opsState'],
+  ): string {
+    switch (state) {
+      case 'armed':
+        return 'border-emerald-300/35 bg-emerald-400/18 text-emerald-50';
+      case 'unsupported':
+        return 'border-slate-300/20 bg-slate-900/70 text-slate-100';
+      default:
+        return 'border-amber-300/35 bg-amber-400/18 text-amber-50';
+    }
+  }
+
+  private resolveMissionEnergyLaneState(
+    fromStatus: AdminQualityMissionExecutionLoopStep['status'],
+    toStatus: AdminQualityMissionExecutionLoopStep['status'],
+  ): AdminQualityMissionEnergyLaneSegment['state'] {
+    if (fromStatus === 'blocked' || toStatus === 'blocked') {
+      return 'fault';
+    }
+
+    if (fromStatus === 'current' || toStatus === 'current') {
+      return 'flowing';
+    }
+
+    if (fromStatus === 'done' && toStatus === 'done') {
+      return 'charged';
+    }
+
+    if (fromStatus === 'done' && toStatus === 'pending') {
+      return 'flowing';
+    }
+
+    return 'standby';
   }
 
   missionCueLabel(): string {
@@ -329,11 +935,15 @@ export class AdminQualityMissionControlComponent {
     }
   }
 
-  heroActions(recommendation: AdminQualityMissionRecommendation): readonly AdminQualityMissionActionDescriptor[] {
+  heroActions(
+    recommendation: AdminQualityMissionRecommendation,
+  ): readonly AdminQualityMissionActionDescriptor[] {
     return missionActionDescriptors(recommendation.status);
   }
 
-  cardActions(recommendation: AdminQualityMissionRecommendation): readonly AdminQualityMissionActionDescriptor[] {
+  cardActions(
+    recommendation: AdminQualityMissionRecommendation,
+  ): readonly AdminQualityMissionActionDescriptor[] {
     return missionActionDescriptors(recommendation.status);
   }
 
@@ -378,7 +988,10 @@ export class AdminQualityMissionControlComponent {
     return `conic-gradient(${color} 0deg ${degrees}, rgba(148,163,184,0.14) ${degrees} 360deg)`;
   }
 
-  emitMissionAction(action: AdminQualityMissionControlAction, recommendation: AdminQualityMissionRecommendation): void {
+  emitMissionAction(
+    action: AdminQualityMissionControlAction,
+    recommendation: AdminQualityMissionRecommendation,
+  ): void {
     this.missionAction.emit({ action, recommendation });
   }
 
@@ -414,7 +1027,10 @@ export class AdminQualityMissionControlComponent {
     }
   }
 
-  isMissionActionBlocked(action: AdminQualityMissionControlAction, recommendation: AdminQualityMissionRecommendation): boolean {
+  isMissionActionBlocked(
+    action: AdminQualityMissionControlAction,
+    recommendation: AdminQualityMissionRecommendation,
+  ): boolean {
     return (
       action === 'auto-delegate' &&
       this.isMissionSelected(recommendation) &&
@@ -474,7 +1090,9 @@ export class AdminQualityMissionControlComponent {
       case 'approval':
         return 'Arbitrage operateur avant depart.';
       case 'execution':
-        return label.includes('bloquee') ? 'Lever le blocage avant reprise.' : 'Suivre issue, artefacts et hypotheses.';
+        return label.includes('bloquee')
+          ? 'Lever le blocage avant reprise.'
+          : 'Suivre issue, artefacts et hypotheses.';
       case 'review':
         return 'Relire tests, preuves et ecarts restants.';
       default:

--- a/openg7-org/src/app/domains/admin/pages/admin-quality.page.html
+++ b/openg7-org/src/app/domains/admin/pages/admin-quality.page.html
@@ -287,6 +287,30 @@
         </div>
 
         <div class="flex flex-wrap items-center gap-3 text-xs">
+          <label
+            class="flex min-w-[15rem] items-center gap-3 rounded-[14px] border border-white/10 bg-[#0c1729] px-3.5 py-2.5 text-sm text-slate-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+          >
+            <span class="text-[11px] font-semibold uppercase tracking-[0.22em] text-cyan-200/80"
+              >AI</span
+            >
+            <select
+              class="min-w-0 flex-1 appearance-none bg-transparent text-sm text-white outline-none"
+              [value]="selectedAiProvider()"
+              (change)="setAiProvider($event)"
+              data-og7="admin-quality-ai-provider"
+              data-og7-id="admin-quality-ai-provider"
+            >
+              @for (provider of aiProviders; track provider.id) {
+              <option [value]="provider.id">{{ provider.label }}</option>
+              }
+            </select>
+          </label>
+          <span
+            class="max-w-[22rem] text-[11px] leading-5 text-slate-400"
+            data-og7-id="admin-quality-ai-provider-caption"
+          >
+            {{ selectedAiProviderCaption() }}
+          </span>
           @if (hasActiveFilters()) {
           <span class="inline-flex items-center gap-1 font-medium text-emerald-100">
             <span class="text-emerald-300" aria-hidden="true">•</span>
@@ -300,6 +324,224 @@
           }
         </div>
       </div>
+
+      @if (selectedMission(); as mission) {
+      <div class="h-px bg-white/10"></div>
+
+      <section
+        class="og7-cockpit-surface relative overflow-hidden rounded-[18px] border border-cyan-300/20 bg-[linear-gradient(180deg,rgba(4,14,30,0.96),rgba(7,20,38,0.94))] px-4 py-3 shadow-[0_24px_70px_-46px_rgba(34,211,238,0.36)] transition-[box-shadow,border-color,transform] duration-500"
+        data-og7="admin-quality-mission-hud"
+        [attr.data-og7-expanded]="missionHudExpanded()"
+        [attr.data-og7-ambient]="missionHudAmbientTone()"
+        [attr.data-og7-cockpit-tone]="missionCockpitToneKey()"
+        [ngStyle]="missionCockpitStyleVars()"
+      >
+        <div
+          class="og7-cockpit-sync-band pointer-events-none absolute inset-x-8 top-0 h-px"
+          data-og7="admin-quality-cockpit-sync-band"
+          data-og7-surface="hud"
+        ></div>
+        <div
+          class="pointer-events-none absolute inset-0 opacity-95 transition-opacity duration-500"
+          [class]="missionHudAmbientOverlayClasses()"
+          data-og7="admin-quality-hud-ambient-layer"
+        ></div>
+
+        <div class="relative grid gap-3 border-b border-white/10 pb-3 xl:grid-cols-[minmax(0,1.4fr)_auto] xl:items-start">
+          <div class="min-w-0 space-y-2">
+            <div class="flex flex-wrap items-center gap-2">
+              <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-200/80">
+                Mission HUD
+              </p>
+              <span
+                class="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="missionHudStatusClasses(mission.status)"
+                data-og7-id="admin-quality-hud-mission-status"
+              >
+                {{ missionHudStatusLabel(mission.status) }}
+              </span>
+              <span
+                class="inline-flex rounded-full border border-cyan-400/25 bg-cyan-400/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-cyan-100"
+              >
+                {{ selectedAiProviderLabel() }}
+              </span>
+              <span
+                class="inline-flex rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-200"
+                data-og7-id="admin-quality-hud-active-section-label"
+              >
+                Zone active · {{ missionHudSectionLabel() }}
+              </span>
+            </div>
+
+            <div class="min-w-0">
+              <h2 class="truncate text-lg font-semibold text-white" data-og7-id="admin-quality-hud-title">
+                {{ mission.title }}
+              </h2>
+              <p class="mt-1 max-w-3xl text-sm leading-6 text-slate-300" data-og7-id="admin-quality-hud-summary">
+                @if (missionHudExpanded()) {
+                {{ selectedEntry()?.domain ?? 'Mission active' }} · {{ selectedAiDispatchWorkflow() }}
+                } @else {
+                {{ missionHudCompactSummary() }}
+                }
+              </p>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2 xl:justify-end">
+            @for (section of missionHudSectionOptions; track section.id) {
+            <button
+              type="button"
+              class="inline-flex min-h-9 items-center justify-center rounded-full border px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] transition"
+              [class]="missionHudSectionClasses(section.id)"
+              [attr.data-og7-active]="missionHudActiveSection() === section.id"
+              [attr.data-og7-pulse]="missionHudSectionPulse(section.id)"
+              [attr.data-og7-id]="'admin-quality-hud-section-' + section.id"
+              data-og7="admin-quality-hud-section-chip"
+              (click)="scrollMissionHudToSection(section.id)"
+            >
+              {{ section.shortLabel }}
+            </button>
+            }
+            <button
+              type="button"
+              class="inline-flex min-h-9 items-center justify-center rounded-full border border-white/12 bg-white/5 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-100 transition hover:bg-white/8"
+              (click)="toggleMissionHud()"
+              data-og7="action"
+              data-og7-id="admin-quality-hud-toggle"
+            >
+              {{ missionHudExpanded() ? 'Compact mode' : 'Expanded mode' }}
+            </button>
+          </div>
+        </div>
+
+        <div class="relative mt-3 grid gap-3 2xl:grid-cols-[minmax(0,1fr)_auto] 2xl:items-center">
+          <div
+            class="rounded-[16px] border border-white/10 bg-white/[0.04] px-3 py-3"
+            data-og7="admin-quality-hud-energy-lane"
+          >
+            <div class="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+              <span>Energy lane</span>
+              <span class="h-px flex-1 bg-white/10"></span>
+            </div>
+            <div class="mt-3 grid grid-cols-[auto_1fr_auto_1fr_auto_1fr_auto] items-center gap-2">
+              <span
+                class="inline-flex h-8 items-center justify-center rounded-full border px-2 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="missionHudEnergyNodeClasses(missionHudEnergyLaneSegments()[0]?.state ?? 'standby')"
+              >
+                Mission
+              </span>
+              @for (segment of missionHudEnergyLaneSegments(); track segment.id) {
+              <div
+                class="h-1.5 rounded-full"
+                [class]="missionHudEnergyTrackClasses(segment.state)"
+                data-og7="admin-quality-hud-energy-segment"
+                [attr.data-og7-id]="segment.id"
+                [attr.data-og7-state]="segment.state"
+              ></div>
+              <span
+                class="inline-flex h-8 items-center justify-center rounded-full border px-2 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="missionHudEnergyNodeClasses(segment.state)"
+              >
+                {{ segment.to }}
+              </span>
+              }
+            </div>
+          </div>
+
+          <div class="flex flex-wrap gap-2 xl:justify-end">
+            <button
+              type="button"
+              class="inline-flex min-h-10 items-center justify-center rounded-[12px] border border-white/12 bg-[#10192b] px-4 py-2 text-sm font-medium text-slate-100 transition hover:bg-[#16233a]"
+              (click)="openWorkspace('delegation')"
+              data-og7="action"
+              data-og7-id="admin-quality-hud-open-workspace"
+            >
+              Ouvrir mission desk
+            </button>
+            <button
+              type="button"
+              class="inline-flex min-h-10 items-center justify-center rounded-[12px] border border-cyan-400/30 bg-cyan-400/10 px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-400/16"
+              (click)="openWorkspace('actions')"
+              data-og7="action"
+              data-og7-id="admin-quality-hud-open-actions"
+            >
+              Ouvrir proof desk
+            </button>
+          </div>
+        </div>
+
+        @if (missionHudExpanded()) {
+        <div class="relative mt-3 grid gap-2 sm:grid-cols-2 xl:min-w-[34rem] xl:grid-cols-4" data-og7="admin-quality-hud-expanded-panels">
+            <article class="rounded-[14px] border border-white/10 bg-white/5 px-3 py-2.5">
+              <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Ops
+              </p>
+              <span
+                class="mt-2 inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="missionHudOpsClasses()"
+                data-og7-id="admin-quality-hud-ops-status"
+              >
+                {{ selectedAiDispatchStatusLabel() }}
+              </span>
+            </article>
+
+            <article class="rounded-[14px] border border-white/10 bg-white/5 px-3 py-2.5">
+              <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Proof
+              </p>
+              @if (selectedAiProofDisplay(); as proof) {
+              <span
+                class="mt-2 inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="missionHudProofClasses(proof.state)"
+                data-og7-id="admin-quality-hud-proof-status"
+                [attr.data-og7-hot]="missionHudProofPulse(proof.state)"
+              >
+                {{ proof.label }}
+              </span>
+              }
+            </article>
+
+            <article class="rounded-[14px] border border-white/10 bg-white/5 px-3 py-2.5">
+              <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Telemetry
+              </p>
+              <span
+                class="mt-2 inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                [class]="missionHudTelemetryClasses(selectedAiTelemetryState())"
+                data-og7-id="admin-quality-hud-telemetry-status"
+              >
+                {{ selectedAiTelemetryLabel() }}
+              </span>
+            </article>
+
+            <article class="rounded-[14px] border border-white/10 bg-white/5 px-3 py-2.5">
+              <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Charge
+              </p>
+              <p
+                class="mt-2 text-sm font-semibold text-white"
+                data-og7-id="admin-quality-hud-required-units"
+              >
+                {{ selectedMissionQuotaSummary()?.requiredUnits ?? 0 }} unit(s)
+              </p>
+            </article>
+          </div>
+
+        <div class="mt-3 flex flex-col gap-3 border-t border-white/10 pt-3 lg:flex-row lg:items-center lg:justify-between">
+          <div class="flex flex-wrap gap-2 text-[11px] font-semibold">
+            @if (selectedAiProofDisplay(); as proof) {
+            <span class="inline-flex rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-slate-200">
+              {{ proof.artifactLabel }}
+            </span>
+            <span class="inline-flex rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-slate-200">
+              {{ proof.pullRequestLabel }}
+            </span>
+            }
+          </div>
+        </div>
+        }
+      </section>
+      }
 
       @if (hasActiveFilters()) {
       <div class="sr-only" data-og7="admin-quality-active-filters">
@@ -316,129 +558,681 @@
       } @else {
       <p class="sr-only">Aucun filtre actif. La vue montre tout le portefeuille QA.</p>
       }
+
+      <div class="border-t border-white/10 pt-3">
+        <og7-admin-quality-command-rail [scope]="commandScopeSummary()" [metrics]="commandMetrics()" />
+      </div>
     </div>
   </section>
-
-  <og7-admin-quality-command-rail [scope]="commandScopeSummary()" [metrics]="commandMetrics()" />
 
   <div
-    class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.08fr)_minmax(23rem,0.92fr)] lg:items-start"
-  >
-    <div class="w-full min-w-0">
-      <og7-admin-quality-coverage-matrix
-        [entries]="filteredEntries()"
-        [selectedEntryId]="selectedEntry()?.id ?? null"
-        (entrySelected)="selectEntry($event)"
-      />
-    </div>
-
-    <div class="flex w-full min-w-0 lg:self-start">
-      @if (missionControl(); as mission) {
-      <og7-admin-quality-mission-control
-        [missionControl]="mission"
-        [snapshotLoaded]="!!snapshot()"
-        [totalDomains]="totalDomains()"
-        [selectedDomain]="selectedEntry()?.domain ?? null"
-        [selectedEntry]="selectedEntry()"
-        [selectedDelegation]="selectedDelegation()"
-        [selectedMission]="selectedMission()"
-        [selectedMissionTasks]="selectedMissionTasks()"
-        [selectedMissionQuotaSummary]="selectedMissionQuotaSummary()"
-        [canStartSelectedMission]="canStartSelectedMission()"
-        [availableCodexQuotaUnits]="availableCodexQuotaUnits()"
-        [speaking]="speaking()"
-        (availableCodexQuotaUnitsChanged)="setAvailableCodexQuotaUnits($event)"
-        (missionSelected)="selectMission($event)"
-        (missionAction)="handleMissionAction($event)"
-        (speakRequested)="speakMissionControl(mission)"
-        (stopSpeakingRequested)="stopMissionVoice()"
-      />
-      }
-    </div>
-  </div>
-
-  <section
-    class="relative mt-8 overflow-hidden rounded-[30px] border border-cyan-400/25 bg-[linear-gradient(180deg,rgba(4,12,28,0.98),rgba(4,13,30,0.96)_50%,rgba(2,8,20,0.98))] p-4 shadow-[0_34px_96px_-60px_rgba(56,189,248,0.42)] xl:p-5"
-    data-og7="admin-quality-workspace-bar"
+    class="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(21rem,0.65fr)] xl:items-start"
+    data-og7="admin-quality-main-cockpit"
   >
     <div
-      class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(56,189,248,0.16),_transparent_24%),radial-gradient(circle_at_18%_18%,_rgba(251,191,36,0.1),_transparent_22%)]"
-    ></div>
-
-    <div class="relative flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-      <div class="min-w-0 space-y-3">
-        <div class="flex flex-wrap items-center gap-2">
-          <p class="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-200/80">
-            {{ 'admin.quality.workspace.compact.label' | translate }}
-          </p>
-          <span
-            class="inline-flex rounded-full border border-amber-300/20 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100"
-          >
-            {{ 'admin.quality.workspace.compact.primarySurface' | translate: { surface:
-            (selectedWorkspaceTitle() | translate) } }}
-          </span>
-        </div>
-
-        <div class="space-y-1">
-          <h2 class="text-2xl font-semibold tracking-tight text-white">
-            {{ 'admin.quality.workspace.compact.title' | translate }}
-          </h2>
-          <p class="max-w-3xl text-sm leading-6 text-slate-300">
-            {{ 'admin.quality.workspace.compact.subtitle' | translate }}
-          </p>
-        </div>
-
-        <div class="flex flex-wrap gap-2 text-sm text-slate-200">
-          <span
-            class="inline-flex rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200"
-          >
-            {{ 'admin.quality.workspace.compact.domains' | translate: { count:
-            filteredEntries().length } }}
-          </span>
-          <span
-            class="inline-flex rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200"
-          >
-            {{ 'admin.quality.workspace.compact.actions' | translate: { count:
-            selectedEntryActions().length } }}
-          </span>
-          <span
-            class="inline-flex rounded-full border border-cyan-300/20 bg-cyan-400/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-cyan-100"
-          >
-            {{ 'admin.quality.workspace.compact.activeSurface' | translate: { surface:
-            (selectedWorkspaceTitle() | translate) } }}
-          </span>
-        </div>
+      #coverageSection
+      class="flex min-w-0 flex-col gap-6"
+      data-og7="admin-quality-scroll-section"
+      data-og7-id="coverage"
+    >
+      <div
+        class="og7-radar-lock-focus-shell w-full min-w-0 rounded-[28px]"
+        [attr.data-og7-lock-focus]="missionControlPanelFocused('coverage')"
+        data-og7="admin-quality-panel-shell"
+        data-og7-id="coverage"
+      >
+        <og7-admin-quality-coverage-matrix
+          [entries]="filteredEntries()"
+          [selectedEntryId]="selectedEntry()?.id ?? null"
+          (entrySelected)="selectEntry($event)"
+        />
       </div>
 
-      <div class="flex flex-col gap-3 xl:min-w-[18rem] xl:max-w-[22rem] xl:items-end">
-        <article class="w-full rounded-[24px] border border-white/10 bg-slate-950/55 p-4 text-left">
-          <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
-            {{ 'admin.quality.workspace.compact.activePanel' | translate }}
-          </p>
-          <p class="mt-2 text-lg font-semibold text-white">
-            {{ selectedWorkspaceTitle() | translate }}
-          </p>
-          <p class="mt-2 text-sm leading-6 text-slate-300">
-            {{ selectedWorkspaceSubtitle() | translate }}
-          </p>
-          <p class="mt-3 text-xs font-medium text-cyan-100">
-            {{ 'admin.quality.workspace.compact.activePanelCount' | translate: { count:
-            selectedWorkspaceCount() } }}
-          </p>
-        </article>
-
-        <button
-          type="button"
-          class="inline-flex min-h-12 items-center justify-center rounded-[18px] border border-cyan-300/25 bg-linear-to-r from-cyan-500 to-blue-500 px-5 py-3 text-sm font-semibold text-white transition hover:from-cyan-400 hover:to-blue-400"
-          (click)="openWorkspace()"
-          data-og7="action"
-          data-og7-id="admin-quality-open-workspace"
+      <details
+        class="rounded-[30px] border border-slate-200/90 bg-slate-50/90 shadow-[0_18px_56px_-40px_rgba(15,23,42,0.2)]"
+        data-og7="admin-quality-secondary-queue"
+      >
+        <summary
+          class="flex cursor-pointer list-none flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+          data-og7-id="admin-quality-secondary-queue-toggle"
         >
-          {{ 'admin.quality.workspace.compact.open' | translate }}
-        </button>
-      </div>
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Surface secondaire
+            </p>
+            <h2 class="mt-1 text-lg font-semibold text-slate-900">QA Queue detaillee</h2>
+            <p class="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
+              Relecture complete de la matrice pour reselectionner un domaine, relire le gap et preparer
+              la prochaine action sans concurrencer la surface principale.
+            </p>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+            <span
+              class="inline-flex rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium"
+            >
+              {{ filteredEntries().length }} domaine(s)
+            </span>
+            <span
+              class="inline-flex rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium"
+            >
+              Reselection manuelle
+            </span>
+          </div>
+        </summary>
+
+        <div class="border-t border-slate-200/80 px-4 py-4 sm:px-5">
+          <section
+            class="rounded-[30px] border border-sky-100/90 bg-white/95 shadow-[0_24px_72px_-44px_rgba(15,23,42,0.18)] backdrop-blur"
+          >
+            <div class="max-h-[40rem] overflow-auto">
+              <table class="min-w-[900px] divide-y divide-slate-200 text-left text-sm text-slate-700">
+                <thead
+                  class="sticky top-0 z-10 bg-slate-50 text-xs uppercase tracking-wide text-slate-500"
+                >
+                  <tr>
+                    <th class="px-4 py-3">Domaine</th>
+                    <th class="px-4 py-3">Diagnostic</th>
+                    <th class="px-4 py-3">Lecture</th>
+                    <th class="px-4 py-3">Prochaine action</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-100">
+                  @if (!filteredEntries().length) {
+                  <tr>
+                    <td
+                      colspan="4"
+                      class="px-4 py-8 text-center text-sm text-slate-500"
+                      data-og7-id="admin-quality-empty"
+                    >
+                      Aucun domaine ne correspond aux filtres actifs.
+                    </td>
+                  </tr>
+                  } @else { @for (entry of filteredEntries(); track entry.id) {
+                  <tr
+                    data-og7="admin-quality-row"
+                    [attr.data-og7-id]="entry.id"
+                    [attr.data-og7-state]="entry.e2eStatus"
+                    [class.bg-slate-50]="isSelected(entry)"
+                  >
+                    <td class="px-4 py-4 align-top">
+                      <button
+                        type="button"
+                        class="w-full text-left"
+                        (click)="selectEntry(entry)"
+                        [attr.aria-pressed]="isSelected(entry)"
+                        data-og7="action"
+                        data-og7-id="admin-quality-select-row"
+                      >
+                        <div class="flex items-start gap-3">
+                          <og7-admin-quality-domain-icon [entryId]="entry.id" size="sm" />
+                          <div class="min-w-0">
+                            <p class="font-semibold text-slate-900">{{ entry.domain }}</p>
+                            <p class="mt-1 text-xs text-slate-500">Revu le {{ entry.reviewedAt }}</p>
+                          </div>
+                        </div>
+                      </button>
+                    </td>
+                    <td class="px-4 py-4 align-top">
+                      <p class="font-medium leading-relaxed text-slate-900">{{ entry.need }}</p>
+                      <p class="mt-2 text-xs leading-relaxed text-slate-600">{{ entry.observedGap }}</p>
+                    </td>
+                    <td class="px-4 py-4 align-top">
+                      <div class="flex flex-wrap gap-1.5">
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="statusClasses(entry.summaryStatus)"
+                          >S {{ statusLabel(entry.summaryStatus) }}</span
+                        >
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="statusClasses(entry.businessStatus)"
+                          >M {{ statusLabel(entry.businessStatus) }}</span
+                        >
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="statusClasses(entry.implementationStatus)"
+                          >I {{ statusLabel(entry.implementationStatus) }}</span
+                        >
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="statusClasses(entry.e2eStatus)"
+                          >E {{ statusLabel(entry.e2eStatus) }}</span
+                        >
+                      </div>
+                      <div class="mt-3 flex flex-wrap gap-1.5">
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="priorityClasses(entry.priority)"
+                          >Priorite {{ priorityLabel(entry.priority) }}</span
+                        >
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="bucketClasses(entry.managementBucket)"
+                          >{{ bucketLabel(entry.managementBucket) }}</span
+                        >
+                        <span
+                          class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class]="readinessClasses(entry)"
+                          >{{ readinessLabel(entry) }}</span
+                        >
+                      </div>
+                      @if (entry.evidence.length) {
+                      <div class="mt-3 space-y-1">
+                        <p class="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Preuve
+                        </p>
+                        <p class="text-xs leading-relaxed text-slate-600">
+                          {{ entry.evidence.length }} reference(s) @if (entry.evidence[0]; as
+                          firstEvidence) {
+                          <span class="text-slate-500"> - {{ firstEvidence }}</span>
+                          }
+                        </p>
+                      </div>
+                      }
+                    </td>
+                    <td class="px-4 py-4 align-top">
+                      <p class="leading-relaxed text-slate-700">{{ entry.nextMove }}</p>
+                    </td>
+                  </tr>
+                  } }
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </details>
     </div>
-  </section>
+
+    <aside
+      class="flex min-w-0 flex-col gap-6 xl:sticky xl:top-[15.5rem]"
+      data-og7="admin-quality-mission-inspector"
+    >
+      <div
+        #missionSection
+        class="flex w-full min-w-0"
+        data-og7="admin-quality-scroll-section"
+        data-og7-id="mission"
+      >
+        @if (missionControl(); as mission) {
+        <section
+          class="og7-cockpit-surface og7-radar-lock-focus-shell relative w-full overflow-hidden rounded-[32px] border p-3 transition-[border-color,box-shadow,background] duration-500"
+          [class]="missionControlShellClasses()"
+          data-og7="admin-quality-mission-control-shell"
+          [attr.data-og7-ambient]="missionHudAmbientTone()"
+          [attr.data-og7-provider]="selectedAiProvider()"
+          [attr.data-og7-cockpit-tone]="missionCockpitToneKey()"
+          [attr.data-og7-proof-stream]="missionControlProofStreamIntensity()"
+          [attr.data-og7-radar-signal]="missionControlRadarSignalTone()"
+          [attr.data-og7-lock-focus]="missionControlPanelFocused('mission')"
+          [ngStyle]="missionControlShellStyleVars()"
+        >
+        <div
+          class="og7-cockpit-sync-band pointer-events-none absolute inset-x-8 top-0 h-px"
+          data-og7="admin-quality-cockpit-sync-band"
+          data-og7-surface="mission"
+        ></div>
+        <div
+          class="pointer-events-none absolute inset-0 opacity-90 transition-opacity duration-500"
+          [class]="missionControlRadarClasses()"
+          data-og7="admin-quality-mission-control-radar"
+          [style.opacity]="missionControlRadarOpacity()"
+        ></div>
+        <div
+          class="og7-radar-sweep pointer-events-none absolute inset-0"
+          data-og7="admin-quality-mission-control-radar-sweep"
+          [attr.data-og7-speed]="missionControlRadarSweepSpeed()"
+          [attr.data-og7-mode]="missionControlRadarSweepMode()"
+          [attr.data-og7-signal]="missionControlRadarSignalTone()"
+          [style.opacity]="missionControlRadarSweepOpacity()"
+        ></div>
+        <svg
+          class="pointer-events-none absolute inset-0 h-full w-full"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          data-og7="admin-quality-mission-control-radar-trails"
+          [style.opacity]="missionControlRadarFieldOpacity()"
+        >
+          @for (point of missionControlRadarEchoPoints(); track point.id) {
+          <line
+            class="og7-radar-trail-line"
+            x1="50"
+            y1="52"
+            [attr.x2]="point.leftPercent"
+            [attr.y2]="point.topPercent"
+            stroke="var(--og7-cockpit-accent-strong)"
+            [attr.stroke-opacity]="missionControlRadarTrailOpacity(point)"
+            [attr.stroke-width]="missionControlRadarTrailWidth(point)"
+            [attr.stroke-dasharray]="missionControlRadarTrailDasharray(point)"
+            stroke-linecap="round"
+            [attr.data-og7-id]="point.id"
+            [attr.data-og7-active]="point.active"
+            [attr.data-og7-pulse]="point.pulsing"
+            [attr.data-og7-intensity]="point.intensity"
+            data-og7="admin-quality-mission-control-radar-trail"
+          />
+          <circle
+            [attr.cx]="point.leftPercent"
+            [attr.cy]="point.topPercent"
+            [attr.r]="missionControlRadarTrailEndpointRadius(point)"
+            fill="var(--og7-cockpit-accent)"
+            [attr.fill-opacity]="missionControlRadarTrailOpacity(point)"
+            [attr.data-og7-id]="point.id"
+            [attr.data-og7-intensity]="point.intensity"
+            data-og7="admin-quality-mission-control-radar-trail-endpoint"
+          />
+          }
+        </svg>
+        <div
+          class="pointer-events-none absolute inset-0"
+          data-og7="admin-quality-mission-control-radar-echo-field"
+          [style.opacity]="missionControlRadarFieldOpacity()"
+        >
+          @for (point of missionControlRadarEchoPoints(); track point.id) {
+          <button
+            type="button"
+            class="pointer-events-auto absolute inline-flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-full border px-2.5 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] transition"
+            [class]="missionControlRadarEchoClasses(point)"
+            [style.left]="point.left"
+            [style.top]="point.top"
+            [attr.data-og7-active]="point.active"
+            [attr.data-og7-pulse]="point.pulsing"
+            [attr.data-og7-id]="point.id"
+            data-og7="admin-quality-mission-control-radar-echo"
+            (click)="scrollMissionHudToSection(point.id)"
+          >
+            <span
+              class="og7-radar-acquisition-ring pointer-events-none absolute inset-[-0.85rem] rounded-full border"
+              [class]="missionControlRadarAcquisitionRingClasses(point)"
+              [attr.data-og7-active]="point.active"
+              [attr.data-og7-pulse]="point.pulsing"
+              [attr.data-og7-id]="point.id"
+              data-og7="admin-quality-mission-control-radar-acquisition-ring"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="pointer-events-none absolute inset-[-0.4rem] rounded-full border transition"
+              [class]="missionControlRadarEchoRingClasses(point)"
+              aria-hidden="true"
+            ></span>
+            <span class="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--og7-cockpit-accent-strong)]"></span>
+            <span class="relative" [class]="missionControlRadarEchoLabelClasses(point)">
+              {{ point.shortLabel }}
+            </span>
+            <span
+              class="relative text-[9px] font-medium normal-case tracking-normal"
+              [class]="missionControlRadarMetricClasses(point)"
+              data-og7="admin-quality-mission-control-radar-echo-metric"
+            >
+              {{ point.metricLabel }}
+            </span>
+          </button>
+          }
+        </div>
+        <div
+          class="pointer-events-none absolute inset-x-8 top-0 h-24 blur-2xl transition-opacity duration-500"
+          [class]="missionControlProviderLightClasses()"
+          data-og7="admin-quality-mission-control-provider-light"
+        ></div>
+
+        <div class="relative mb-3 flex items-start justify-between gap-3">
+          <div class="space-y-2">
+            <div class="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">
+              <span>Mission radar</span>
+              <span class="h-px w-10 bg-white/10"></span>
+              <span class="text-slate-400">{{ missionHudAmbientTone() }}</span>
+              <span
+                class="inline-flex rounded-full border px-2 py-0.5 text-[9px] font-semibold tracking-[0.18em]"
+                [class]="missionControlContactLogSignalClasses(missionControlDisplaySignalTone())"
+                data-og7="admin-quality-mission-control-cadence"
+              >
+                {{ missionControlRadarCadenceLabel() }}
+              </span>
+            </div>
+            <p
+              class="text-[10px] font-medium tracking-[0.14em] text-slate-400"
+              data-og7="admin-quality-mission-control-cadence-detail"
+            >
+              {{ missionControlRadarCadenceDetail() }}
+            </p>
+            <div
+              class="inline-flex flex-col rounded-[16px] border px-3 py-2 text-left"
+              [class]="missionControlContactLockClasses()"
+              data-og7="admin-quality-mission-control-contact-lock"
+            >
+              <span class="text-[10px] font-semibold uppercase tracking-[0.2em]">
+                {{ missionControlContactLockLabel() }}
+              </span>
+              <span class="mt-1 text-[11px] text-slate-300/90">
+                {{ missionControlContactLockDetail() }}
+              </span>
+            </div>
+            <div class="grid gap-1.5" data-og7="admin-quality-mission-control-contact-log">
+              @for (entry of missionControlRadarLockLog(); track entry.sequence; let index = $index) {
+              <button
+                type="button"
+                class="inline-flex items-center gap-2 rounded-[14px] border px-3 py-2 text-[10px] text-left transition hover:border-white/20 hover:bg-white/[0.08]"
+                [class]="missionControlContactLogEntryClasses(index)"
+                [attr.data-og7-age]="missionControlContactLogAge(index)"
+                [attr.data-og7-id]="entry.id"
+                [attr.data-og7-kind]="entry.kind"
+                [attr.data-og7-state]="entry.stateLabel.toLowerCase()"
+                [attr.data-og7-reason]="entry.reason ?? null"
+                [attr.data-og7-signal]="entry.signalTone"
+                data-og7="admin-quality-mission-control-contact-log-entry"
+                (click)="focusMissionControlLockEntry(entry.id)"
+              >
+                <span
+                  class="inline-flex rounded-full border px-2 py-0.5 font-mono text-[9px] font-semibold tracking-[0.18em]"
+                  [class]="missionControlContactLogTimeClasses(index)"
+                  [attr.data-og7-age]="missionControlContactLogAge(index)"
+                  data-og7="admin-quality-mission-control-contact-log-time"
+                >
+                  {{ missionControlTimelineSlotLabel(index) }}
+                </span>
+                <span class="font-semibold uppercase tracking-[0.18em] text-slate-200/80">
+                  {{ index === 0 ? `Latest ${entry.kindLabel.toLowerCase()}` : `T-${index} ${entry.kindLabel.toLowerCase()}` }}
+                </span>
+                <span
+                  class="inline-flex rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.18em]"
+                  [class]="missionControlContactLogSignalClasses(entry.signalTone)"
+                  data-og7="admin-quality-mission-control-contact-log-reason"
+                >
+                  {{ entry.reasonLabel }}
+                </span>
+                <span class="text-slate-100/95">
+                  {{ entry.detailLabel }}
+                </span>
+                <span class="text-slate-400/90">
+                  {{ missionControlTimelineCadenceLabel(index) }} · {{ entry.metricLabel }} · proof {{ entry.proofStream }}
+                </span>
+              </button>
+              }
+            </div>
+          </div>
+          <span
+            class="inline-flex rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em]"
+            [class]="missionControlProviderSignatureClasses()"
+            data-og7="admin-quality-mission-control-signature"
+          >
+            {{ missionControlProviderSignatureLabel() }}
+          </span>
+        </div>
+
+        <div class="relative">
+          <og7-admin-quality-mission-control
+            [missionControl]="mission"
+            [snapshotLoaded]="!!snapshot()"
+            [totalDomains]="totalDomains()"
+            [selectedDomain]="selectedEntry()?.domain ?? null"
+            [selectedEntry]="selectedEntry()"
+            [selectedDelegation]="selectedDelegation()"
+            [selectedMission]="selectedMission()"
+            [selectedMissionTasks]="selectedMissionTasks()"
+            [selectedMissionQuotaSummary]="selectedMissionQuotaSummary()"
+            [canStartSelectedMission]="canStartSelectedMission()"
+            [selectedAiProviderLabel]="selectedAiProviderLabel()"
+            [selectedAiProviderCaption]="selectedAiProviderCaption()"
+            [aiDispatchReady]="selectedAiDispatchReady()"
+            [aiDispatchStatusLabel]="selectedAiDispatchStatusLabel()"
+            [aiDispatchStatusDetail]="selectedAiDispatchStatusDetail()"
+            [aiDispatchWorkflow]="selectedAiDispatchWorkflow()"
+            [aiTelemetryState]="selectedAiTelemetryState()"
+            [aiTelemetryLabel]="selectedAiTelemetryLabel()"
+            [aiTelemetryDetail]="selectedAiTelemetryDetail()"
+            [aiDispatching]="selectedAiDispatching()"
+            [selectedAiProof]="selectedAiProofDisplay()"
+            [providerComparison]="aiProviderComparison()"
+            [speaking]="speaking()"
+            (missionSelected)="selectMission($event)"
+            (missionAction)="handleMissionAction($event)"
+            (speakRequested)="speakMissionControl(mission)"
+            (stopSpeakingRequested)="stopMissionVoice()"
+          />
+        </div>
+        </section>
+        }
+      </div>
+
+      <section
+        #workspaceSection
+        class="og7-radar-lock-focus-shell relative overflow-hidden rounded-[30px] border border-cyan-400/25 bg-[linear-gradient(180deg,rgba(4,12,28,0.98),rgba(4,13,30,0.96)_50%,rgba(2,8,20,0.98))] p-4 shadow-[0_34px_96px_-60px_rgba(56,189,248,0.42)] xl:p-5"
+        data-og7="admin-quality-workspace-bar"
+        data-og7-id="workspace"
+        [attr.data-og7-lock-focus]="missionControlPanelFocused('workspace')"
+      >
+        <div
+          class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(56,189,248,0.16),_transparent_24%),radial-gradient(circle_at_18%_18%,_rgba(251,191,36,0.1),_transparent_22%)]"
+        ></div>
+
+        <div class="relative flex flex-col gap-4">
+          <div class="min-w-0 space-y-3">
+            <div class="flex flex-wrap items-center gap-2">
+              <p class="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-200/80">
+                {{ 'admin.quality.workspace.compact.label' | translate }}
+              </p>
+              <span
+                class="inline-flex rounded-full border border-amber-300/20 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100"
+              >
+                {{ 'admin.quality.workspace.compact.primarySurface' | translate: { surface:
+                (selectedWorkspaceTitle() | translate) } }}
+              </span>
+            </div>
+
+            <div class="space-y-1">
+              <h2 class="text-xl font-semibold tracking-tight text-white">
+                {{ 'admin.quality.workspace.compact.title' | translate }}
+              </h2>
+              <p class="text-sm leading-6 text-slate-300">
+                {{ 'admin.quality.workspace.compact.subtitle' | translate }}
+              </p>
+            </div>
+
+            <div class="flex flex-wrap gap-2 text-sm text-slate-200">
+              <span
+                class="inline-flex rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200"
+              >
+                {{ 'admin.quality.workspace.compact.domains' | translate: { count:
+                filteredEntries().length } }}
+              </span>
+              <span
+                class="inline-flex rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200"
+              >
+                {{ 'admin.quality.workspace.compact.actions' | translate: { count:
+                selectedEntryActions().length } }}
+              </span>
+              <span
+                class="inline-flex rounded-full border border-cyan-300/20 bg-cyan-400/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-cyan-100"
+              >
+                {{ 'admin.quality.workspace.compact.activeSurface' | translate: { surface:
+                (selectedWorkspaceTitle() | translate) } }}
+              </span>
+            </div>
+          </div>
+
+          <div
+            class="grid grid-cols-3 gap-2 rounded-[22px] border border-white/10 bg-white/[0.04] p-1"
+            role="tablist"
+            aria-label="Workspace inspector"
+            data-og7="admin-quality-workspace-inspector-tabs"
+          >
+            <button
+              type="button"
+              role="tab"
+              class="rounded-[18px] px-3 py-3 text-sm font-medium transition"
+              [class.bg-cyan-400/12]="activeWorkspaceSurface() === 'qaQueue'"
+              [class.border]="true"
+              [class.border-cyan-300/20]="activeWorkspaceSurface() === 'qaQueue'"
+              [class.text-white]="activeWorkspaceSurface() === 'qaQueue'"
+              [class.border-transparent]="activeWorkspaceSurface() !== 'qaQueue'"
+              [class.text-slate-300]="activeWorkspaceSurface() !== 'qaQueue'"
+              [attr.aria-selected]="activeWorkspaceSurface() === 'qaQueue'"
+              data-og7="action"
+              data-og7-id="admin-quality-inspector-tab-qaQueue"
+              (click)="setActiveWorkspaceSurface('qaQueue')"
+            >
+              {{ 'admin.quality.workspace.tabs.qaQueue' | translate }}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              class="rounded-[18px] px-3 py-3 text-sm font-medium transition"
+              [class.bg-cyan-400/12]="activeWorkspaceSurface() === 'delegation'"
+              [class.border]="true"
+              [class.border-cyan-300/20]="activeWorkspaceSurface() === 'delegation'"
+              [class.text-white]="activeWorkspaceSurface() === 'delegation'"
+              [class.border-transparent]="activeWorkspaceSurface() !== 'delegation'"
+              [class.text-slate-300]="activeWorkspaceSurface() !== 'delegation'"
+              [attr.aria-selected]="activeWorkspaceSurface() === 'delegation'"
+              data-og7="action"
+              data-og7-id="admin-quality-inspector-tab-delegation"
+              (click)="setActiveWorkspaceSurface('delegation')"
+            >
+              {{ 'admin.quality.workspace.tabs.delegation' | translate }}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              class="rounded-[18px] px-3 py-3 text-sm font-medium transition"
+              [class.bg-cyan-400/12]="activeWorkspaceSurface() === 'actions'"
+              [class.border]="true"
+              [class.border-cyan-300/20]="activeWorkspaceSurface() === 'actions'"
+              [class.text-white]="activeWorkspaceSurface() === 'actions'"
+              [class.border-transparent]="activeWorkspaceSurface() !== 'actions'"
+              [class.text-slate-300]="activeWorkspaceSurface() !== 'actions'"
+              [attr.aria-selected]="activeWorkspaceSurface() === 'actions'"
+              data-og7="action"
+              data-og7-id="admin-quality-inspector-tab-actions"
+              (click)="setActiveWorkspaceSurface('actions')"
+            >
+              {{ 'admin.quality.workspace.tabs.actions' | translate }}
+            </button>
+          </div>
+
+          <article class="rounded-[24px] border border-white/10 bg-slate-950/55 p-4 text-left">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+                  {{ 'admin.quality.workspace.compact.activePanel' | translate }}
+                </p>
+                <p class="mt-2 text-lg font-semibold text-white">
+                  {{ selectedWorkspaceTitle() | translate }}
+                </p>
+                <p class="mt-2 text-sm leading-6 text-slate-300">
+                  {{ selectedWorkspaceSubtitle() | translate }}
+                </p>
+              </div>
+              <span class="inline-flex rounded-full border border-cyan-300/20 bg-cyan-400/10 px-2.5 py-1 text-[11px] font-semibold text-cyan-100">
+                {{ selectedWorkspaceCount() }}
+              </span>
+            </div>
+
+            <div class="mt-4" data-og7="admin-quality-workspace-inspector-panel" [attr.data-og7-id]="activeWorkspaceSurface()">
+              @switch (activeWorkspaceSurface()) {
+                @case ('qaQueue') {
+                  @if (qaQueuePreviewItems().length) {
+                  <div class="space-y-3">
+                    @for (entry of qaQueuePreviewItems(); track entry.id) {
+                    <article class="rounded-[20px] border border-white/10 bg-white/[0.04] p-3.5" data-og7="admin-quality-workspace-inspector-qa-item" [attr.data-og7-id]="entry.id">
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                          <h3 class="text-sm font-semibold text-white">{{ entry.domain }}</h3>
+                          <p class="mt-1 text-xs leading-5 text-slate-300">{{ entry.need }}</p>
+                        </div>
+                        <span class="inline-flex shrink-0 rounded-full border px-2 py-1 text-[10px] font-semibold" [class]="statusClasses(entry.e2eStatus)">
+                          {{ statusLabel(entry.e2eStatus) }}
+                        </span>
+                      </div>
+                      <p class="mt-3 text-xs leading-5 text-slate-400">{{ entry.nextMove }}</p>
+                    </article>
+                    }
+                  </div>
+                  } @else {
+                  <p class="rounded-[18px] border border-dashed border-white/14 bg-white/[0.03] px-4 py-5 text-sm leading-6 text-slate-300">
+                    {{ 'admin.quality.workspace.qaQueue.emptyBody' | translate }}
+                  </p>
+                  }
+                }
+                @case ('actions') {
+                  @if (actionPreviewItems().length) {
+                  <div class="space-y-3">
+                    @for (action of actionPreviewItems(); track action.id) {
+                    <article class="rounded-[20px] border border-white/10 bg-white/[0.04] p-3.5" data-og7="admin-quality-workspace-inspector-action-item" [attr.data-og7-id]="action.id">
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                          <h3 class="text-sm font-semibold text-white">{{ action.label }}</h3>
+                          <p class="mt-1 break-all text-[11px] text-slate-400">{{ action.selector }}</p>
+                        </div>
+                        <span
+                          class="inline-flex shrink-0 rounded-full border px-2 py-1 text-[10px] font-semibold"
+                          [class.border-emerald-300/20]="action.status === 'proved'"
+                          [class.bg-emerald-400/12]="action.status === 'proved'"
+                          [class.text-emerald-100]="action.status === 'proved'"
+                          [class.border-sky-300/20]="action.status === 'documented'"
+                          [class.bg-sky-400/12]="action.status === 'documented'"
+                          [class.text-sky-100]="action.status === 'documented'"
+                          [class.border-amber-300/25]="action.status === 'needs-completion'"
+                          [class.bg-amber-400/12]="action.status === 'needs-completion'"
+                          [class.text-amber-100]="action.status === 'needs-completion'"
+                        >
+                          {{ action.status }}
+                        </span>
+                      </div>
+                      <p class="mt-3 text-xs leading-5 text-slate-300">{{ action.expectedResult }}</p>
+                    </article>
+                    }
+                  </div>
+                  } @else {
+                  <p class="rounded-[18px] border border-dashed border-white/14 bg-white/[0.03] px-4 py-5 text-sm leading-6 text-slate-300">
+                    {{ 'admin.quality.workspace.actions.emptyBody' | translate }}
+                  </p>
+                  }
+                }
+                @default {
+                  @if (selectedDelegation(); as plan) {
+                  <div class="space-y-3">
+                    <article class="rounded-[20px] border border-white/10 bg-white/[0.04] p-3.5">
+                      <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200/80">
+                        {{ plan.track }}
+                      </p>
+                      <h3 class="mt-2 text-sm font-semibold text-white">{{ plan.title }}</h3>
+                      <p class="mt-2 text-xs leading-6 text-slate-300">
+                        {{ selectedEntry()?.nextMove || ('admin.quality.workspace.delegation.missing' | translate) }}
+                      </p>
+                    </article>
+                    <article class="rounded-[20px] border border-white/10 bg-slate-950/55 p-3.5">
+                      <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                        {{ 'admin.quality.workspace.delegation.cards.validation' | translate }}
+                      </p>
+                      <ul class="mt-3 space-y-2 text-xs leading-6 text-slate-300">
+                        @for (item of plan.commands.slice(0, 3); track $index) {
+                        <li class="break-all">{{ item }}</li>
+                        }
+                      </ul>
+                    </article>
+                  </div>
+                  } @else {
+                  <p class="rounded-[18px] border border-dashed border-white/14 bg-white/[0.03] px-4 py-5 text-sm leading-6 text-slate-300">
+                    {{ 'admin.quality.workspace.delegation.missing' | translate }}
+                  </p>
+                  }
+                }
+              }
+            </div>
+          </article>
+
+          <button
+            type="button"
+            class="inline-flex min-h-12 items-center justify-center rounded-[18px] border border-cyan-300/25 bg-linear-to-r from-cyan-500 to-blue-500 px-5 py-3 text-sm font-semibold text-white transition hover:from-cyan-400 hover:to-blue-400"
+            (click)="openWorkspace()"
+            data-og7="action"
+            data-og7-id="admin-quality-open-workspace"
+          >
+            {{ 'admin.quality.workspace.compact.open' | translate }}
+          </button>
+        </div>
+      </section>
+    </aside>
+  </div>
 
   <og7-admin-quality-workspace-drawer
     [open]="workspaceOpen()"
@@ -453,160 +1247,6 @@
     (closeRequested)="closeWorkspace()"
     (surfaceChanged)="setActiveWorkspaceSurface($event)"
   />
-
-  <details
-    class="mt-6 rounded-[30px] border border-slate-200/90 bg-slate-50/90 shadow-[0_18px_56px_-40px_rgba(15,23,42,0.2)]"
-    data-og7="admin-quality-secondary-queue"
-  >
-    <summary
-      class="flex cursor-pointer list-none flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
-      data-og7-id="admin-quality-secondary-queue-toggle"
-    >
-      <div>
-        <p class="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-          Surface secondaire
-        </p>
-        <h2 class="mt-1 text-lg font-semibold text-slate-900">QA Queue detaillee</h2>
-        <p class="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-          Relecture complete de la matrice pour reselectionner un domaine, relire le gap et preparer
-          la prochaine action sans concurrencer la surface principale.
-        </p>
-      </div>
-      <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-        <span
-          class="inline-flex rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium"
-        >
-          {{ filteredEntries().length }} domaine(s)
-        </span>
-        <span
-          class="inline-flex rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium"
-        >
-          Reselection manuelle
-        </span>
-      </div>
-    </summary>
-
-    <div class="border-t border-slate-200/80 px-4 py-4 sm:px-5">
-      <section
-        class="rounded-[30px] border border-sky-100/90 bg-white/95 shadow-[0_24px_72px_-44px_rgba(15,23,42,0.18)] backdrop-blur"
-      >
-        <div class="max-h-[40rem] overflow-auto">
-          <table class="min-w-[900px] divide-y divide-slate-200 text-left text-sm text-slate-700">
-            <thead
-              class="sticky top-0 z-10 bg-slate-50 text-xs uppercase tracking-wide text-slate-500"
-            >
-              <tr>
-                <th class="px-4 py-3">Domaine</th>
-                <th class="px-4 py-3">Diagnostic</th>
-                <th class="px-4 py-3">Lecture</th>
-                <th class="px-4 py-3">Prochaine action</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-100">
-              @if (!filteredEntries().length) {
-              <tr>
-                <td
-                  colspan="4"
-                  class="px-4 py-8 text-center text-sm text-slate-500"
-                  data-og7-id="admin-quality-empty"
-                >
-                  Aucun domaine ne correspond aux filtres actifs.
-                </td>
-              </tr>
-              } @else { @for (entry of filteredEntries(); track entry.id) {
-              <tr
-                data-og7="admin-quality-row"
-                [attr.data-og7-id]="entry.id"
-                [attr.data-og7-state]="entry.e2eStatus"
-                [class.bg-slate-50]="isSelected(entry)"
-              >
-                <td class="px-4 py-4 align-top">
-                  <button
-                    type="button"
-                    class="w-full text-left"
-                    (click)="selectEntry(entry)"
-                    [attr.aria-pressed]="isSelected(entry)"
-                    data-og7="action"
-                    data-og7-id="admin-quality-select-row"
-                  >
-                    <div class="flex items-start gap-3">
-                      <og7-admin-quality-domain-icon [entryId]="entry.id" size="sm" />
-                      <div class="min-w-0">
-                        <p class="font-semibold text-slate-900">{{ entry.domain }}</p>
-                        <p class="mt-1 text-xs text-slate-500">Revu le {{ entry.reviewedAt }}</p>
-                      </div>
-                    </div>
-                  </button>
-                </td>
-                <td class="px-4 py-4 align-top">
-                  <p class="font-medium leading-relaxed text-slate-900">{{ entry.need }}</p>
-                  <p class="mt-2 text-xs leading-relaxed text-slate-600">{{ entry.observedGap }}</p>
-                </td>
-                <td class="px-4 py-4 align-top">
-                  <div class="flex flex-wrap gap-1.5">
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="statusClasses(entry.summaryStatus)"
-                      >S {{ statusLabel(entry.summaryStatus) }}</span
-                    >
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="statusClasses(entry.businessStatus)"
-                      >M {{ statusLabel(entry.businessStatus) }}</span
-                    >
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="statusClasses(entry.implementationStatus)"
-                      >I {{ statusLabel(entry.implementationStatus) }}</span
-                    >
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="statusClasses(entry.e2eStatus)"
-                      >E {{ statusLabel(entry.e2eStatus) }}</span
-                    >
-                  </div>
-                  <div class="mt-3 flex flex-wrap gap-1.5">
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="priorityClasses(entry.priority)"
-                      >Priorite {{ priorityLabel(entry.priority) }}</span
-                    >
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="bucketClasses(entry.managementBucket)"
-                      >{{ bucketLabel(entry.managementBucket) }}</span
-                    >
-                    <span
-                      class="inline-flex rounded-full border px-2 py-1 text-[10px] font-semibold"
-                      [class]="readinessClasses(entry)"
-                      >{{ readinessLabel(entry) }}</span
-                    >
-                  </div>
-                  @if (entry.evidence.length) {
-                  <div class="mt-3 space-y-1">
-                    <p class="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                      Preuve
-                    </p>
-                    <p class="text-xs leading-relaxed text-slate-600">
-                      {{ entry.evidence.length }} reference(s) @if (entry.evidence[0]; as
-                      firstEvidence) {
-                      <span class="text-slate-500"> - {{ firstEvidence }}</span>
-                      }
-                    </p>
-                  </div>
-                  }
-                </td>
-                <td class="px-4 py-4 align-top">
-                  <p class="leading-relaxed text-slate-700">{{ entry.nextMove }}</p>
-                </td>
-              </tr>
-              } }
-            </tbody>
-          </table>
-        </div>
-      </section>
-    </div>
-  </details>
 
   }
 </section>

--- a/openg7-org/src/app/domains/admin/pages/admin-quality.page.spec.ts
+++ b/openg7-org/src/app/domains/admin/pages/admin-quality.page.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router, provideRouter } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import {
   NotificationStore,
   NotificationStoreApi,
@@ -7,6 +7,7 @@ import {
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
+import { AdminOpsService } from '../data-access/admin-ops.service';
 import {
   AdminQualityMatrixService,
   AdminQualityMatrixSnapshot,
@@ -106,8 +107,217 @@ class AdminQualityMissionDecisionsServiceMock {
     );
 }
 
+class AdminOpsServiceMock {
+  readonly getSecurity = jasmine.createSpy('getSecurity').and.returnValue(
+    of({
+      generatedAt: '2026-04-30T00:00:00.000Z',
+      users: {
+        total: 3,
+        blocked: 0,
+        registrationsLast7d: 1,
+      },
+      sessions: {
+        scannedUsers: 3,
+        truncated: false,
+        active: 1,
+        revoked: 0,
+        usersWithActiveSessions: 1,
+      },
+      uploads: {
+        safetyEnabled: true,
+        maxFileSizeBytes: 5242880,
+        allowedMimeTypes: ['image/png'],
+      },
+      auth: {
+        sessionIdleTimeoutMs: 43200000,
+      },
+      aiKeys: [
+        {
+          provider: 'codex',
+          label: 'Codex',
+          workflow: 'codex-pr.yml',
+          secretName: 'OPENAI_API_KEY',
+          dispatchEnabled: true,
+          keyInserted: true,
+          state: 'ready',
+          note: 'Key detected. The engine bay is armed and ready for dispatch.',
+        },
+        {
+          provider: 'copilot',
+          label: 'GitHub Copilot',
+          workflow: 'copilot-pr.yml',
+          secretName: null,
+          dispatchEnabled: false,
+          keyInserted: false,
+          state: 'unsupported',
+          note: 'No stable ignition key is wired for this console yet.',
+        },
+        {
+          provider: 'claude',
+          label: 'Claude',
+          workflow: 'claude-pr.yml',
+          secretName: 'ANTHROPIC_API_KEY',
+          dispatchEnabled: true,
+          keyInserted: true,
+          state: 'ready',
+          note: 'Key detected. The engine bay is armed and ready for dispatch.',
+        },
+        {
+          provider: 'gemini',
+          label: 'Gemini',
+          workflow: 'gemini-pr.yml',
+          secretName: 'GEMINI_API_KEY',
+          dispatchEnabled: false,
+          keyInserted: false,
+          state: 'offline',
+          note: 'Insert GEMINI_API_KEY into GitHub Actions secrets to power this module.',
+        },
+      ],
+      moderation: {
+        pendingCompanies: 0,
+        suspendedCompanies: 0,
+      },
+    }),
+  );
+  readonly getAiProofs = jasmine.createSpy('getAiProofs').and.returnValue(
+    of({
+      generatedAt: '2026-04-30T00:12:00.000Z',
+      providers: [
+        {
+          provider: 'codex',
+          label: 'Codex',
+          workflow: 'codex-pr.yml',
+          state: 'completed' as const,
+          summary: 'Workflow #51 completed with 2 artifact(s) and PR #321.',
+          run: {
+            id: 501,
+            number: 51,
+            url: 'https://github.com/OpenG7/openg7-platform/actions/runs/501',
+            status: 'completed',
+            conclusion: 'success',
+            branch: 'codex/qa-proof-501',
+            createdAt: '2026-04-30T00:00:00.000Z',
+            updatedAt: '2026-04-30T00:08:00.000Z',
+          },
+          artifacts: [
+            {
+              id: 9001,
+              name: 'playwright-report',
+              sizeBytes: 2048,
+              expired: false,
+              url: 'https://github.com/OpenG7/openg7-platform/actions/runs/501#artifacts',
+            },
+            {
+              id: 9002,
+              name: 'logs',
+              sizeBytes: 1024,
+              expired: false,
+              url: 'https://github.com/OpenG7/openg7-platform/actions/runs/501#artifacts',
+            },
+          ],
+          pullRequest: {
+            number: 321,
+            title: 'Codex QA proof package',
+            url: 'https://github.com/OpenG7/openg7-platform/pull/321',
+            state: 'open',
+            merged: false,
+            branch: 'codex/qa-proof-501',
+          },
+        },
+        {
+          provider: 'copilot',
+          label: 'GitHub Copilot',
+          workflow: 'copilot-pr.yml',
+          state: 'failed' as const,
+          summary: 'Workflow #7 finished with conclusion failure.',
+          run: {
+            id: 701,
+            number: 7,
+            url: 'https://github.com/OpenG7/openg7-platform/actions/runs/701',
+            status: 'completed',
+            conclusion: 'failure',
+            branch: 'copilot/placeholder-701',
+            createdAt: '2026-04-30T00:12:00.000Z',
+            updatedAt: '2026-04-30T00:13:00.000Z',
+          },
+          artifacts: [],
+          pullRequest: null,
+        },
+        {
+          provider: 'claude',
+          label: 'Claude',
+          workflow: 'claude-pr.yml',
+          state: 'in-progress' as const,
+          summary: 'Workflow #18 is executing on claude/qa-proof-601.',
+          run: {
+            id: 601,
+            number: 18,
+            url: 'https://github.com/OpenG7/openg7-platform/actions/runs/601',
+            status: 'in_progress',
+            conclusion: null,
+            branch: 'claude/qa-proof-601',
+            createdAt: '2026-04-30T00:10:00.000Z',
+            updatedAt: '2026-04-30T00:11:00.000Z',
+          },
+          artifacts: [
+            {
+              id: 9003,
+              name: 'draft-proof',
+              sizeBytes: 512,
+              expired: false,
+              url: 'https://github.com/OpenG7/openg7-platform/actions/runs/601#artifacts',
+            },
+          ],
+          pullRequest: {
+            number: 322,
+            title: 'Claude draft improvements',
+            url: 'https://github.com/OpenG7/openg7-platform/pull/322',
+            state: 'open',
+            merged: false,
+            branch: 'claude/qa-proof-601',
+          },
+        },
+        {
+          provider: 'gemini',
+          label: 'Gemini',
+          workflow: 'gemini-pr.yml',
+          state: 'unavailable' as const,
+          summary: 'No workflow run detected yet for gemini-pr.yml.',
+          run: null,
+          artifacts: [],
+          pullRequest: null,
+        },
+      ],
+    }),
+  );
+  readonly dispatchCodexWorkflow = jasmine
+    .createSpy('dispatchCodexWorkflow')
+    .and.callFake((payload: { provider: 'codex' | 'copilot' | 'claude' | 'gemini' }) =>
+      of({
+        queued: true,
+        provider: 'github-actions' as const,
+        selectedProvider: payload.provider,
+        owner: 'OpenG7',
+        repo: 'openg7-platform',
+        workflow: `${payload.provider}-pr.yml`,
+        ref: 'main',
+        requestedAt: '2026-04-30T00:00:00.000Z',
+        request: {
+          selectedProvider: payload.provider,
+          scope: 'openg7-org' as const,
+          baseBranch: 'main',
+          draftPr: true,
+          model: 'gpt-5.4',
+          effort: null,
+          taskLength: 49,
+        },
+      }),
+    );
+}
+
 describe('AdminQualityPage', () => {
   let service: AdminQualityMatrixServiceMock;
+  let opsService: AdminOpsServiceMock;
   let missionDecisions: AdminQualityMissionDecisionsServiceMock;
   let notifications: jasmine.SpyObj<NotificationStoreApi>;
 
@@ -115,6 +325,7 @@ describe('AdminQualityPage', () => {
     localStorage.removeItem('og7.admin-quality.mission-control.v1');
     localStorage.removeItem('og7.admin-quality.view-state.v1');
     service = new AdminQualityMatrixServiceMock();
+    opsService = new AdminOpsServiceMock();
     missionDecisions = new AdminQualityMissionDecisionsServiceMock();
     notifications = jasmine.createSpyObj<NotificationStoreApi>('NotificationStoreApi', [
       'success',
@@ -127,6 +338,7 @@ describe('AdminQualityPage', () => {
       providers: [
         provideRouter([]),
         { provide: AdminQualityMatrixService, useValue: service },
+        { provide: AdminOpsService, useValue: opsService },
         { provide: AdminQualityMissionDecisionsService, useValue: missionDecisions },
         { provide: NotificationStore, useValue: notifications },
       ],
@@ -238,27 +450,29 @@ describe('AdminQualityPage', () => {
             },
             codex: {
               runway: {
-                label: 'Codex runway',
-                title: 'Generated task runway',
-                subtitle: 'Estimate the task volume before starting the selected mission.',
+                label: 'Codex Ops clearance',
+                title: 'Generated task plan',
+                subtitle:
+                  'Review the estimated task volume and live Ops readiness before dispatch.',
                 status: {
-                  sufficient: 'Quota sufficient',
-                  insufficient: 'Quota insufficient',
+                  sufficient: 'Ops ready',
+                  insufficient: 'Ops blocked',
                 },
                 metrics: {
                   tasks: 'Tasks',
                   tasksBody: 'Generated from the active mission.',
-                  required: 'Required quota',
+                  required: 'Estimated units',
                   requiredBody: 'Estimated units for the current plan.',
-                  available: 'Available quota',
-                  availableBody: 'Local operator estimate until Codex usage is connected.',
-                  remaining: 'Runway left',
-                  remainingBody: 'Units left after this mission.',
-                  missing: 'Units missing',
-                  missingBody: 'Increase the quota before launching the task.',
+                  available: 'Ops status',
+                  availableBody: 'Live readiness from Owner Ops.',
+                  remaining: 'Workflow',
+                  remainingBody: 'GitHub Actions workflow selected by the backend.',
+                  missing: 'Workflow',
+                  missingBody: 'Fix the Ops readiness blocker before dispatch.',
                 },
-                ready: 'The mission can be delegated without exceeding the current quota estimate.',
-                blocked: 'Increase the available quota before launching the generated task set.',
+                ready: 'The mission can be dispatched directly from Mission Control.',
+                blocked:
+                  'Dispatch is blocked until Ops reports an enabled workflow and inserted key.',
               },
               tasks: {
                 label: 'Generated tasks',
@@ -273,8 +487,7 @@ describe('AdminQualityPage', () => {
                 },
               },
               notifications: {
-                insufficientQuota:
-                  'Quota too low: {{ required }} unit(s) required, {{ available }} available, {{ missing }} missing.',
+                insufficientQuota: 'Ops readiness is blocking dispatch.',
               },
             },
           },
@@ -651,6 +864,9 @@ describe('AdminQualityPage', () => {
     const missionControl = root.querySelector('[data-og7="admin-quality-mission-control"]');
     const missionHero = root.querySelector('[data-og7="admin-quality-mission-hero"]');
     const missionWorkflow = root.querySelector('[data-og7="admin-quality-mission-workflow"]');
+    const missionControlShell = root.querySelector(
+      '[data-og7="admin-quality-mission-control-shell"]',
+    );
     const recommendations = root.querySelectorAll('[data-og7="admin-quality-recommendation"]');
     let recommendationButtons = root.querySelectorAll(
       '[data-og7="admin-quality-recommendation"] > button',
@@ -664,7 +880,7 @@ describe('AdminQualityPage', () => {
     expect(missionControl?.textContent).toContain('Gap constate');
     expect(missionControl?.textContent).toContain('Mission suggeree');
     expect(missionControl?.textContent).toContain('Valider mission');
-    expect(missionControl?.textContent).toContain('Deleguer');
+    expect(missionControl?.textContent).toContain('Lancer Codex');
     expect(recommendations.length).toBe(3);
     expect(root.textContent).toContain('Validation humaine requise');
     expect(recommendationButtons[0]?.getAttribute('aria-pressed')).toBe('true');
@@ -682,10 +898,40 @@ describe('AdminQualityPage', () => {
     const updatedApproveButton = root.querySelector(
       '[data-og7-id="admin-quality-approve-mission"]',
     ) as HTMLButtonElement;
+    const missionControlRadarSweep = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar-sweep"]',
+    );
+    const missionControlCadence = root.querySelector(
+      '[data-og7="admin-quality-mission-control-cadence"]',
+    );
+    const missionControlCadenceDetail = root.querySelector(
+      '[data-og7="admin-quality-mission-control-cadence-detail"]',
+    );
     updatedApproveButton.click();
     fixture.detectChanges();
 
+    const contactLogEntries = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-contact-log-entry"]',
+    );
+    const contactLogTimes = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-contact-log-time"]',
+    );
+
     expect(root.textContent).toContain('Pret a lancer');
+    expect(missionControlShell?.getAttribute('data-og7-radar-signal')).toBe('primary');
+    expect(missionControlRadarSweep?.getAttribute('data-og7-mode')).toBe('action');
+    expect(missionControlCadence?.textContent).toContain('2 events / active cycle');
+    expect(missionControlCadenceDetail?.textContent).toContain('1 lock');
+    expect(missionControlCadenceDetail?.textContent).toContain('1 action');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-kind')).toBe('action');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-id')).toBe('mission');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-signal')).toBe('primary');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-age')).toBe('current');
+    expect(contactLogTimes[0]?.textContent).toContain('T+0');
+    expect(contactLogEntries[0]?.textContent).toContain('Latest action');
+    expect(contactLogEntries[0]?.textContent).toContain('Approve');
+    expect(contactLogEntries[0]?.textContent).toContain('now');
+    expect(contactLogEntries[1]?.getAttribute('data-og7-age')).toBe('recent');
     expect(notifications.success).toHaveBeenCalledWith('Mission approuvee par un humain.', {
       source: 'admin-quality',
     });
@@ -697,7 +943,7 @@ describe('AdminQualityPage', () => {
     );
   });
 
-  it('generates mission tasks and shows a sufficient quota runway for the active mission', () => {
+  it('generates mission tasks and shows Ops readiness for the active mission', () => {
     const fixture = TestBed.createComponent(AdminQualityPage);
     fixture.detectChanges();
 
@@ -708,57 +954,442 @@ describe('AdminQualityPage', () => {
     const generatedTaskCount = root.querySelector(
       '[data-og7-id="admin-quality-generated-task-count"]',
     );
+    const telemetryStatus = root.querySelector('[data-og7-id="admin-quality-ai-telemetry-status"]');
+    const telemetryDetail = root.querySelector('[data-og7-id="admin-quality-ai-telemetry-detail"]');
+    const missionLoop = root.querySelector('[data-og7="admin-quality-mission-loop"]');
+    const missionLoopSteps = root.querySelectorAll('[data-og7="admin-quality-mission-loop-step"]');
+    const missionEnergyLane = root.querySelector('[data-og7="admin-quality-mission-energy-lane"]');
+    const missionEnergySegments = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-energy-lane-segment"]',
+    );
+    const missionHud = root.querySelector('[data-og7="admin-quality-mission-hud"]');
+    const missionHudAmbientLayer = root.querySelector(
+      '[data-og7="admin-quality-hud-ambient-layer"]',
+    );
+    const missionControlShell = root.querySelector(
+      '[data-og7="admin-quality-mission-control-shell"]',
+    );
+    const missionControlRadar = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar"]',
+    );
+    const missionControlRadarSweep = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar-sweep"]',
+    );
+    const missionControlAcquisitionRings = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-radar-acquisition-ring"]',
+    );
+    const missionControlRadarTrails = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-radar-trail"]',
+    );
+    const missionControlRadarEndpoints = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-radar-trail-endpoint"]',
+    );
+    const missionControlRadarEchoes = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-radar-echo"]',
+    );
+    const missionControlSignature = root.querySelector(
+      '[data-og7="admin-quality-mission-control-signature"]',
+    );
+    const missionControlContactLock = root.querySelector(
+      '[data-og7="admin-quality-mission-control-contact-lock"]',
+    );
+    const contactLogEntries = root.querySelectorAll(
+      '[data-og7="admin-quality-mission-control-contact-log-entry"]',
+    );
+    const coveragePanel = root.querySelector(
+      '[data-og7="admin-quality-panel-shell"][data-og7-id="coverage"]',
+    );
+    const workspacePanel = root.querySelector('[data-og7="admin-quality-workspace-bar"]');
+    const missionControlCadence = root.querySelector(
+      '[data-og7="admin-quality-mission-control-cadence"]',
+    );
+    const missionControlCadenceDetail = root.querySelector(
+      '[data-og7="admin-quality-mission-control-cadence-detail"]',
+    );
+    const cockpitSyncBands = root.querySelectorAll('[data-og7="admin-quality-cockpit-sync-band"]');
+    const missionHudMiniLane = root.querySelector('[data-og7="admin-quality-hud-energy-lane"]');
+    const missionHudMiniSegments = root.querySelectorAll(
+      '[data-og7="admin-quality-hud-energy-segment"]',
+    );
+    const proofTelemetry = root.querySelector('[data-og7="admin-quality-proof-telemetry"]');
 
     expect(runway).not.toBeNull();
-    expect(quotaStatus?.textContent).toContain('Quota sufficient');
+    expect(missionHud).not.toBeNull();
+    expect(missionHud?.getAttribute('data-og7-expanded')).toBe('true');
+    expect(missionHud?.getAttribute('data-og7-ambient')).toBe('nominal');
+    expect(missionHud?.getAttribute('data-og7-cockpit-tone')).toBe('codex');
+    expect(missionHudAmbientLayer).not.toBeNull();
+    expect(missionControlShell?.getAttribute('data-og7-ambient')).toBe('nominal');
+    expect(missionControlShell?.getAttribute('data-og7-provider')).toBe('codex');
+    expect(missionControlShell?.getAttribute('data-og7-cockpit-tone')).toBe('codex');
+    expect(missionControlShell?.getAttribute('data-og7-proof-stream')).toBe('high');
+    expect(missionControlShell?.getAttribute('data-og7-radar-signal')).toBe('pulse');
+    expect(missionControlRadar).not.toBeNull();
+    expect(missionControlRadarSweep).not.toBeNull();
+    expect(missionControlRadarSweep?.getAttribute('data-og7-speed')).toBe('nominal');
+    expect(missionControlRadarSweep?.getAttribute('data-og7-mode')).toBe('lock');
+    expect(missionControlCadence?.textContent).toContain('1 event / active cycle');
+    expect(missionControlCadenceDetail?.textContent).toContain('1 lock');
+    expect(missionControlCadenceDetail?.textContent).toContain('0 action');
+    expect(missionControlAcquisitionRings.length).toBe(3);
+    expect(missionControlRadarTrails.length).toBe(3);
+    expect(missionControlRadarEndpoints.length).toBe(3);
+    expect(missionControlRadarEchoes.length).toBe(3);
+    expect(
+      root
+        .querySelector('[data-og7="admin-quality-mission-control-radar-echo"][data-og7-id="coverage"]')
+        ?.getAttribute('data-og7-active'),
+    ).toBe('true');
+    expect(
+      root
+        .querySelector(
+          '[data-og7="admin-quality-mission-control-radar-acquisition-ring"][data-og7-id="coverage"]',
+        )
+        ?.getAttribute('data-og7-active'),
+    ).toBe('true');
+    expect(
+      root
+        .querySelector('[data-og7="admin-quality-mission-control-radar-trail"][data-og7-id="coverage"]')
+        ?.getAttribute('data-og7-intensity'),
+    ).toBe('high');
+    expect(
+      root
+        .querySelector('[data-og7="admin-quality-mission-control-radar-echo"][data-og7-id="workspace"]')
+        ?.getAttribute('data-og7-active'),
+    ).toBe('false');
+    expect(missionControlSignature?.textContent).toContain('Codex spectrum');
+    expect(missionControlContactLock?.textContent).toContain('Contact lock');
+    expect(missionControlContactLock?.textContent).toContain('Coverage matrix');
+    expect(missionControlContactLock?.textContent).toContain('3/3');
+    expect(contactLogEntries.length).toBe(1);
+    expect(contactLogEntries[0]?.getAttribute('data-og7-kind')).toBe('lock');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-id')).toBe('coverage');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-state')).toBe('locked');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-reason')).toBe('section-pulse');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-signal')).toBe('pulse');
+    expect(contactLogEntries[0]?.getAttribute('data-og7-age')).toBe('current');
+    expect(
+      root.querySelector('[data-og7="admin-quality-mission-control-contact-log-time"]')?.textContent,
+    ).toContain('T+0');
+    expect(contactLogEntries[0]?.textContent).toContain('Latest lock');
+    expect(contactLogEntries[0]?.textContent).toContain('Section pulse');
+    expect(contactLogEntries[0]?.textContent).toContain('now');
+    expect(contactLogEntries[0]?.textContent).toContain('Coverage matrix');
+    expect(coveragePanel?.getAttribute('data-og7-lock-focus')).toBe('true');
+    expect(missionControlShell?.getAttribute('data-og7-lock-focus')).toBe('false');
+    expect(workspacePanel?.getAttribute('data-og7-lock-focus')).toBe('false');
+    expect(cockpitSyncBands.length).toBe(2);
+    expect(missionHud?.textContent).toContain('Etendre la preuve QA');
+    expect(missionHud?.textContent).toContain('Recherche et decouverte profonde');
+    expect(missionHudMiniLane).not.toBeNull();
+    expect(missionHudMiniSegments.length).toBe(3);
+    expect(missionHudMiniSegments[0]?.getAttribute('data-og7-state')).toBe('flowing');
+    expect(root.querySelector('[data-og7-id="admin-quality-hud-ops-status"]')?.textContent).toContain(
+      'Ops pret',
+    );
+    expect(
+      root.querySelector('[data-og7-id="admin-quality-hud-proof-status"]')?.textContent,
+    ).toContain('Proof package ready');
+    expect(
+      root.querySelector('[data-og7-id="admin-quality-hud-proof-status"]')?.getAttribute(
+        'data-og7-hot',
+      ),
+    ).toBe('true');
+    expect(missionLoop).not.toBeNull();
+    expect(missionLoopSteps.length).toBe(4);
+    expect(missionEnergyLane).not.toBeNull();
+    expect(missionEnergySegments.length).toBe(3);
+    expect(missionEnergySegments[0]?.getAttribute('data-og7-state')).toBe('flowing');
+    expect(missionEnergySegments[1]?.getAttribute('data-og7-state')).toBe('standby');
+    expect(proofTelemetry?.textContent).toContain(
+      'Workflow #51 completed with 2 artifact(s) and PR #321.',
+    );
+    expect(proofTelemetry?.textContent).toContain('2 artifact(s)');
+    expect(proofTelemetry?.textContent).toContain('PR #321');
+    expect(quotaStatus?.textContent).toContain('Ops ready');
     expect(generatedTasks.length).toBe(8);
     expect(generatedTaskCount?.textContent).toContain('8');
     expect(runway?.textContent).toContain(
-      'The mission can be delegated without exceeding the current quota estimate.',
+      'The mission can be dispatched directly from Mission Control.',
     );
+    expect(
+      root.querySelector('[data-og7-id="admin-quality-codex-ops-status"]')?.textContent,
+    ).toContain('Ops pret');
+    expect(telemetryStatus?.textContent).toContain('Live pulse nominal');
+    expect(telemetryStatus?.getAttribute('data-og7-state')).toBe('live');
+    expect(telemetryDetail?.textContent).toContain('Next sweep in');
+    expect(
+      root
+        .querySelector('[data-og7="admin-quality-mission-loop-step"][data-og7-id="dispatch"]')
+        ?.getAttribute('data-og7-status'),
+    ).toBe('pending');
   });
 
-  it('blocks delegation when the available quota is below the generated task estimate', () => {
+  it('toggles the sticky mission HUD between expanded and compact modes', () => {
     const fixture = TestBed.createComponent(AdminQualityPage);
     fixture.detectChanges();
 
     const root = fixture.nativeElement as HTMLElement;
-    const quotaInput = root.querySelector(
-      '[data-og7-id="admin-quality-codex-quota-input"]',
-    ) as HTMLInputElement;
+    const toggleButton = root.querySelector(
+      '[data-og7-id="admin-quality-hud-toggle"]',
+    ) as HTMLButtonElement;
 
-    quotaInput.value = '40';
-    quotaInput.dispatchEvent(new Event('input'));
+    expect(root.querySelector('[data-og7="admin-quality-hud-expanded-panels"]')).not.toBeNull();
+
+    toggleButton.click();
     fixture.detectChanges();
 
+    expect(fixture.componentInstance.missionHudExpanded()).toBeFalse();
+    expect(root.querySelector('[data-og7="admin-quality-hud-expanded-panels"]')).toBeNull();
+    expect(root.querySelector('[data-og7="admin-quality-mission-hud"]')?.getAttribute('data-og7-expanded')).toBe(
+      'false',
+    );
+    expect(root.querySelector('[data-og7-id="admin-quality-hud-summary"]')?.textContent).toContain(
+      'Ops pret',
+    );
+  });
+
+  it('opens the workspace directly from the sticky mission HUD actions', () => {
+    const fixture = TestBed.createComponent(AdminQualityPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const proofDeskButton = root.querySelector(
+      '[data-og7-id="admin-quality-hud-open-actions"]',
+    ) as HTMLButtonElement;
+
+    proofDeskButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.workspaceOpen()).toBeTrue();
+    expect(fixture.componentInstance.activeWorkspaceSurface()).toBe('actions');
+    expect(root.querySelector('[data-og7="admin-quality-workspace-drawer"]')).not.toBeNull();
+  });
+
+  it('updates the sticky mission HUD active section when a section chip is selected', () => {
+    const fixture = TestBed.createComponent(AdminQualityPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const workspaceChip = root.querySelector(
+      '[data-og7-id="admin-quality-hud-section-workspace"]',
+    ) as HTMLButtonElement;
+    const workspaceEcho = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar-echo"][data-og7-id="workspace"]',
+    ) as HTMLButtonElement;
+    const workspaceTrail = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar-trail"][data-og7-id="workspace"]',
+    );
+    const contactLock = root.querySelector(
+      '[data-og7="admin-quality-mission-control-contact-lock"]',
+    );
+    const contactLog = () =>
+      Array.from(
+        root.querySelectorAll('[data-og7="admin-quality-mission-control-contact-log-entry"]'),
+      );
+    const workspacePanel = root.querySelector('[data-og7="admin-quality-workspace-bar"]');
+    const coveragePanel = root.querySelector(
+      '[data-og7="admin-quality-panel-shell"][data-og7-id="coverage"]',
+    );
+    const missionControlShell = root.querySelector(
+      '[data-og7="admin-quality-mission-control-shell"]',
+    );
+    const missionControlRadarSweep = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar-sweep"]',
+    );
+    const missionControlCadence = root.querySelector(
+      '[data-og7="admin-quality-mission-control-cadence"]',
+    );
+    const missionControlCadenceDetail = root.querySelector(
+      '[data-og7="admin-quality-mission-control-cadence-detail"]',
+    );
+    const contactLogTimes = () =>
+      Array.from(root.querySelectorAll('[data-og7="admin-quality-mission-control-contact-log-time"]'));
+
+    workspaceChip.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.missionHudActiveSection()).toBe('workspace');
+    expect(
+      root.querySelector('[data-og7-id="admin-quality-hud-active-section-label"]')?.textContent,
+    ).toContain('Workspace deck');
+    expect(workspaceChip.getAttribute('data-og7-active')).toBe('true');
+    expect(workspaceChip.getAttribute('data-og7-pulse')).toBe('true');
+    expect(workspaceEcho.getAttribute('data-og7-active')).toBe('true');
+    expect(workspaceEcho.getAttribute('data-og7-pulse')).toBe('true');
+    expect(workspaceTrail?.getAttribute('data-og7-active')).toBe('true');
+    expect(workspaceTrail?.getAttribute('data-og7-pulse')).toBe('true');
+    expect(workspaceTrail?.getAttribute('data-og7-intensity')).toBe('low');
+    expect(contactLock?.textContent).toContain('Acquiring Workspace deck');
+    expect(contactLock?.textContent).toContain('1 surface(s)');
+    expect(contactLog().length).toBe(2);
+    expect(contactLog()[0]?.getAttribute('data-og7-id')).toBe('workspace');
+    expect(contactLog()[0]?.getAttribute('data-og7-kind')).toBe('lock');
+    expect(contactLog()[0]?.getAttribute('data-og7-state')).toBe('acquiring');
+    expect(contactLog()[0]?.getAttribute('data-og7-reason')).toBe('manual-targeting');
+    expect(contactLog()[0]?.getAttribute('data-og7-signal')).toBe('manual');
+    expect(contactLog()[0]?.textContent).toContain('Latest lock');
+    expect(contactLog()[0]?.textContent).toContain('Manual targeting');
+    expect(contactLogTimes()[0]?.textContent).toContain('T+0');
+    expect(contactLogTimes()[1]?.textContent).toContain('T-1');
+    expect(contactLog()[0]?.getAttribute('data-og7-age')).toBe('current');
+    expect(contactLog()[1]?.getAttribute('data-og7-age')).toBe('recent');
+    expect(contactLog()[0]?.textContent).toContain('Workspace deck');
+    expect(missionControlShell?.getAttribute('data-og7-radar-signal')).toBe('manual');
+    expect(missionControlRadarSweep?.getAttribute('data-og7-mode')).toBe('lock');
+    expect(missionControlCadence?.textContent).toContain('2 events / active cycle');
+    expect(contactLog()[1]?.getAttribute('data-og7-id')).toBe('coverage');
+    expect(contactLog()[1]?.getAttribute('data-og7-state')).toBe('locked');
+    expect(workspacePanel?.getAttribute('data-og7-lock-focus')).toBe('true');
+    expect(coveragePanel?.getAttribute('data-og7-lock-focus')).toBe('false');
+
+    (contactLog()[1] as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.missionHudActiveSection()).toBe('coverage');
+    expect(contactLog().length).toBe(3);
+    expect(contactLog()[0]?.getAttribute('data-og7-id')).toBe('coverage');
+    expect(contactLog()[0]?.getAttribute('data-og7-reason')).toBe('manual-targeting');
+    expect(contactLog()[0]?.textContent).toContain('Manual targeting');
+    expect(contactLog()[2]?.getAttribute('data-og7-age')).toBe('stale');
+    expect(contactLogTimes()[2]?.textContent).toContain('T-2');
+    expect(missionControlCadence?.textContent).toContain('3 events / active cycle');
+    expect(missionControlCadenceDetail?.textContent).toContain('3 lock');
+    expect(coveragePanel?.getAttribute('data-og7-lock-focus')).toBe('true');
+  });
+
+  it('renders a multi-provider comparison deck driven by Ops readiness and proof telemetry', () => {
+    const fixture = TestBed.createComponent(AdminQualityPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const cards = root.querySelectorAll('[data-og7="admin-quality-provider-comparison-card"]');
+    const codexCard = root.querySelector(
+      '[data-og7="admin-quality-provider-comparison-card"][data-og7-id="codex"]',
+    );
+    const claudeCard = root.querySelector(
+      '[data-og7="admin-quality-provider-comparison-card"][data-og7-id="claude"]',
+    );
+
+    expect(cards.length).toBe(4);
+    expect(codexCard?.textContent).toContain('Ops armed');
+    expect(codexCard?.textContent).toContain('Proof package ready');
+    expect(codexCard?.textContent).toContain('PR #321');
+    expect(codexCard?.getAttribute('data-og7-selected')).toBe('true');
+    expect(claudeCard?.textContent).toContain('Proof pipeline active');
+    expect(claudeCard?.getAttribute('data-og7-proof-state')).toBe('in-progress');
+  });
+
+  it('blocks delegation when Ops readiness does not allow dispatch', () => {
+    opsService.getSecurity.and.returnValue(
+      of({
+        aiKeys: [
+          {
+            provider: 'codex',
+            label: 'Codex',
+            workflow: 'codex-pr.yml',
+            secretName: 'OPENAI_API_KEY',
+            dispatchEnabled: false,
+            keyInserted: true,
+            state: 'ready',
+            note: 'Key detected. The engine bay stays in standby until dispatch is enabled.',
+          },
+        ],
+      }),
+    );
+
+    const fixture = TestBed.createComponent(AdminQualityPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
     const delegateButton = Array.from(root.querySelectorAll('[data-og7="action"]')).find(
-      (element) => element.textContent?.trim() === 'Deleguer',
+      (element) => element.textContent?.trim() === 'Lancer Codex',
     ) as HTMLButtonElement | undefined;
     const quotaStatus = root.querySelector('[data-og7-id="admin-quality-codex-quota-status"]');
 
-    expect(fixture.componentInstance.availableCodexQuotaUnits()).toBe(40);
-    expect(quotaStatus?.textContent).toContain('Quota insufficient');
+    expect(fixture.componentInstance.selectedAiDispatchReady()).toBeFalse();
+    expect(quotaStatus?.textContent).toContain('Ops blocked');
     expect(delegateButton?.disabled).toBeTrue();
 
     delegateButton?.click();
     fixture.detectChanges();
 
     expect(root.textContent).toContain(
-      'Increase the available quota before launching the generated task set.',
+      'Dispatch is blocked until Ops reports an enabled workflow and inserted key.',
     );
     expect(notifications.error).not.toHaveBeenCalled();
+    expect(opsService.dispatchCodexWorkflow).not.toHaveBeenCalled();
     expect(fixture.componentInstance.selectedMission()?.status).toBe('proposed');
   });
 
-  it('opens admin ops with a prefilled Codex dispatch when delegation starts', () => {
-    const router = TestBed.inject(Router);
-    const navigateSpy = spyOn(router, 'navigate').and.resolveTo(true);
+  it('uses the selected provider Ops module to arm or constrain dispatch', () => {
+    const fixture = TestBed.createComponent(AdminQualityPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const providerSelect = root.querySelector(
+      '[data-og7-id="admin-quality-ai-provider"]',
+    ) as HTMLSelectElement;
+    const quotaStatus = root.querySelector('[data-og7-id="admin-quality-codex-quota-status"]');
+    const aiBay = root.querySelector('[data-og7="admin-quality-ai-bay"]');
+    const aiBayStatus = root.querySelector('[data-og7-id="admin-quality-ai-bay-status"]');
+    const telemetryStatus = root.querySelector('[data-og7-id="admin-quality-ai-telemetry-status"]');
+    const missionControlShell = root.querySelector(
+      '[data-og7="admin-quality-mission-control-shell"]',
+    );
+    const missionControlSignature = root.querySelector(
+      '[data-og7="admin-quality-mission-control-signature"]',
+    );
+    const missionHud = root.querySelector('[data-og7="admin-quality-mission-hud"]');
+    const missionControlRadarSweep = root.querySelector(
+      '[data-og7="admin-quality-mission-control-radar-sweep"]',
+    );
+
+    expect(fixture.componentInstance.selectedAiDispatchReady()).toBeTrue();
+    expect(quotaStatus?.textContent).toContain('Ops ready');
+    expect(aiBay?.getAttribute('data-og7-state')).toBe('armed');
+    expect(aiBayStatus?.textContent).toContain('Ops armed');
+    expect(telemetryStatus?.getAttribute('data-og7-state')).toBe('live');
+    expect(missionControlShell?.getAttribute('data-og7-provider')).toBe('codex');
+    expect(missionControlShell?.getAttribute('data-og7-cockpit-tone')).toBe('codex');
+    expect(missionHud?.getAttribute('data-og7-cockpit-tone')).toBe('codex');
+    expect(missionControlRadarSweep?.getAttribute('data-og7-speed')).toBe('nominal');
+    expect(missionControlSignature?.textContent).toContain('Codex spectrum');
+
+    providerSelect.value = 'copilot';
+    providerSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.selectedAiProvider()).toBe('copilot');
+    expect(fixture.componentInstance.selectedAiDispatchReady()).toBeFalse();
+    expect(quotaStatus?.textContent).toContain('Ops blocked');
+    expect(aiBay?.textContent).toContain('GitHub Copilot console');
+    expect(aiBay?.getAttribute('data-og7-state')).toBe('constrained');
+    expect(aiBayStatus?.textContent).toContain('Ops constrained');
+
+    providerSelect.value = 'claude';
+    providerSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.selectedAiProvider()).toBe('claude');
+    expect(fixture.componentInstance.selectedAiDispatchReady()).toBeTrue();
+    expect(quotaStatus?.textContent).toContain('Ops ready');
+    expect(missionControlShell?.getAttribute('data-og7-provider')).toBe('claude');
+    expect(missionControlShell?.getAttribute('data-og7-ambient')).toBe('syncing');
+    expect(missionControlShell?.getAttribute('data-og7-cockpit-tone')).toBe('claude');
+    expect(missionHud?.getAttribute('data-og7-cockpit-tone')).toBe('claude');
+    expect(missionControlRadarSweep?.getAttribute('data-og7-speed')).toBe('fast');
+    expect(missionControlSignature?.textContent).toContain('Claude ember line');
+  });
+
+  it('dispatches the selected mission directly from Mission Control when delegation starts', () => {
+    spyOn(window, 'confirm').and.returnValue(true);
     const fixture = TestBed.createComponent(AdminQualityPage);
     fixture.detectChanges();
 
     const root = fixture.nativeElement as HTMLElement;
     const delegateButton = Array.from(root.querySelectorAll('[data-og7="action"]')).find(
-      (element) => element.textContent?.trim() === 'Deleguer',
+      (element) => element.textContent?.trim() === 'Lancer Codex',
     ) as HTMLButtonElement | undefined;
 
     delegateButton?.click();
@@ -771,20 +1402,35 @@ describe('AdminQualityPage', () => {
         status: 'in-progress',
       }),
     );
-    expect(navigateSpy).toHaveBeenCalledWith(['/admin/ops'], {
-      queryParams: jasmine.objectContaining({
-        codexScope: 'openg7-org',
-        codexBaseBranch: 'main',
-        codexDraftPr: 'true',
-        codexSource: 'admin-quality',
-        codexMissionId: 'advanced-discovery::core',
-      }),
+    expect(opsService.dispatchCodexWorkflow).toHaveBeenCalledWith({
+      provider: 'codex',
+      task: jasmine.stringContaining('Recherche et decouverte profonde'),
+      scope: 'openg7-org',
+      baseBranch: 'main',
+      draftPr: true,
+      model: 'gpt-5.4',
+      effort: null,
     });
-    const queryParams = navigateSpy.calls.mostRecent().args[1]?.queryParams as Record<
-      string,
-      string
-    >;
-    expect(queryParams['codexTask']).toContain('Recherche et decouverte profonde');
+    expect(notifications.info).toHaveBeenCalledWith('Codex queued via codex-pr.yml on main.', {
+      source: 'admin-quality',
+    });
+    expect(
+      root
+        .querySelector('[data-og7="admin-quality-mission-loop-step"][data-og7-id="dispatch"]')
+        ?.getAttribute('data-og7-status'),
+    ).toBe('done');
+    expect(
+      root
+        .querySelector(
+          '[data-og7="admin-quality-mission-energy-lane-segment"][data-og7-id="dispatch-proof"]',
+        )
+        ?.getAttribute('data-og7-state'),
+    ).toBe('flowing');
+    expect(
+      root
+        .querySelector('[data-og7="admin-quality-mission-loop-step"][data-og7-id="proof"]')
+        ?.getAttribute('data-og7-status'),
+    ).toBe('pending');
   });
 
   it('renders the compact actions list in the workspace drawer and updates it on row change', () => {

--- a/openg7-org/src/app/domains/admin/pages/admin-quality.page.ts
+++ b/openg7-org/src/app/domains/admin/pages/admin-quality.page.ts
@@ -1,20 +1,38 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
+  NgZone,
   OnInit,
   PLATFORM_ID,
+  ViewChild,
   computed,
   effect,
   inject,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Router, RouterLink } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { injectNotificationStore } from '@app/core/observability/notification.store';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { catchError, finalize, forkJoin, of } from 'rxjs';
 
+import {
+  ADMIN_AI_PROVIDER_OPTIONS,
+  AdminAiProvider,
+  isAdminAiProvider,
+  resolveAdminAiProviderOption,
+} from '../data-access/admin-ai-providers';
+import {
+  AdminOpsCodexScope,
+  AdminOpsAiProofSnapshot,
+  AdminOpsSecuritySnapshot,
+  AdminOpsService,
+} from '../data-access/admin-ops.service';
 import {
   AdminQualityMatrixBucket,
   AdminQualityMatrixEntry,
@@ -48,6 +66,8 @@ import { AdminQualityCoverageMatrixComponent } from './admin-quality-coverage-ma
 import { AdminQualityDelegationPlan, buildDelegationPlan } from './admin-quality-delegation';
 import { AdminQualityDomainIconComponent } from './admin-quality-domain-icon.component';
 import {
+  AdminQualityMissionActionTone,
+  AdminQualityMissionControlAction,
   AdminQualityMissionControlActionEvent,
   resolveMissionAction,
 } from './admin-quality-mission-actions';
@@ -58,7 +78,11 @@ import {
   AdminQualityMissionStatus,
   buildMissionControl,
 } from './admin-quality-mission-control';
-import { AdminQualityMissionControlComponent } from './admin-quality-mission-control.component';
+import {
+  AdminQualityMissionControlComponent,
+  AdminQualityMissionProofDisplay,
+  AdminQualityMissionProviderComparisonEntry,
+} from './admin-quality-mission-control.component';
 import {
   AdminQualityMissionQuotaSummary,
   AdminQualityMissionTask,
@@ -69,9 +93,62 @@ import {
 type FilterValue<T extends string> = 'all' | T;
 type AdminQualityLegacyInspectionSurface = 'delegation' | 'actions';
 type AdminQualityMissionDecisionSyncStatus = 'local' | 'syncing' | 'server' | 'unavailable';
+type AdminQualityAiOpsSyncStatus = 'loading' | 'ready' | 'unavailable';
+type AdminQualityAiOpsModule = AdminOpsSecuritySnapshot['aiKeys'][number];
+type AdminQualityAiProofModule = AdminOpsAiProofSnapshot['providers'][number];
+type AdminQualityAiTelemetryState = 'live' | 'degraded' | 'syncing' | 'offline';
+type AdminQualityMissionHudSection = 'coverage' | 'mission' | 'workspace';
+type AdminQualityMissionHudLaneState = 'charged' | 'flowing' | 'standby' | 'fault';
+type AdminQualityMissionHudAmbientTone = 'nominal' | 'syncing' | 'warning' | 'critical';
+type AdminQualityMissionRadarEchoIntensity = 'low' | 'medium' | 'high';
+type AdminQualityMissionRadarLockReason = 'manual-targeting' | 'section-pulse' | 'proof-surge';
+type AdminQualityMissionRadarTimelineKind = 'lock' | 'action' | 'proof';
+type AdminQualityMissionRadarSignalTone =
+  | 'manual'
+  | 'pulse'
+  | 'proof'
+  | AdminQualityMissionActionTone;
 interface AdminQualityActiveFilterChip {
   readonly id: string;
   readonly label: string;
+}
+interface AdminQualityMissionRadarEchoPoint {
+  readonly id: AdminQualityMissionHudSection;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly metricLabel: string;
+  readonly leftPercent: number;
+  readonly topPercent: number;
+  readonly left: string;
+  readonly top: string;
+  readonly intensity: AdminQualityMissionRadarEchoIntensity;
+  readonly active: boolean;
+  readonly pulsing: boolean;
+}
+interface AdminQualityMissionRadarLockHistoryEntry {
+  readonly sequence: number;
+  readonly id: AdminQualityMissionHudSection;
+  readonly kind: AdminQualityMissionRadarTimelineKind;
+  readonly stateLabel: string;
+  readonly reason?: AdminQualityMissionRadarLockReason;
+  readonly action?: AdminQualityMissionControlAction;
+  readonly actionTone?: AdminQualityMissionActionTone;
+  readonly detailLabel?: string;
+}
+interface AdminQualityMissionRadarLockDisplayEntry extends AdminQualityMissionRadarLockHistoryEntry {
+  readonly label: string;
+  readonly metricLabel: string;
+  readonly proofStream: AdminQualityMissionRadarEchoIntensity;
+  readonly reasonLabel: string;
+  readonly kindLabel: string;
+  readonly signalTone: AdminQualityMissionRadarSignalTone;
+  readonly detailLabel: string;
+}
+interface AdminQualityMissionHudLaneSegment {
+  readonly id: string;
+  readonly from: string;
+  readonly to: string;
+  readonly state: AdminQualityMissionHudLaneState;
 }
 interface AdminQualityPersistedViewState {
   readonly search?: string;
@@ -83,12 +160,15 @@ interface AdminQualityPersistedViewState {
   readonly selectedActionId?: string | null;
   readonly selectedMissionId?: string | null;
   readonly activeWorkspaceSurface?: AdminQualityWorkspaceSurface;
-  readonly availableCodexQuotaUnits?: number;
+  readonly selectedAiProvider?: AdminAiProvider;
+  readonly missionHudExpanded?: boolean;
   readonly inspectionSurface?: AdminQualityLegacyInspectionSurface;
 }
 
 const MISSION_CONTROL_STORAGE_KEY = 'og7.admin-quality.mission-control.v1';
 const VIEW_STATE_STORAGE_KEY = 'og7.admin-quality.view-state.v1';
+const ADMIN_QUALITY_AI_OPS_REFRESH_INTERVAL_MS = 30_000;
+const ADMIN_QUALITY_LIVE_TICK_INTERVAL_MS = 1_000;
 
 @Component({
   standalone: true,
@@ -104,17 +184,273 @@ const VIEW_STATE_STORAGE_KEY = 'og7.admin-quality.view-state.v1';
     AdminQualityWorkspaceDrawerComponent,
   ],
   templateUrl: './admin-quality.page.html',
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .og7-cockpit-surface {
+        isolation: isolate;
+        --og7-cockpit-accent: rgba(34, 211, 238, 0.2);
+        --og7-cockpit-accent-strong: rgba(34, 211, 238, 0.4);
+        --og7-cockpit-secondary: rgba(56, 189, 248, 0.16);
+        --og7-cockpit-outline: rgba(34, 211, 238, 0.18);
+        --og7-cockpit-glow: rgba(34, 211, 238, 0.26);
+        --og7-cockpit-sweep: rgba(103, 232, 249, 0.38);
+        --og7-cockpit-band: rgba(34, 211, 238, 0.22);
+        --og7-cockpit-sweep-duration: 16s;
+      }
+
+      .og7-cockpit-surface::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        box-shadow:
+          inset 0 0 0 1px var(--og7-cockpit-outline),
+          0 0 46px -28px var(--og7-cockpit-glow);
+        opacity: 0.95;
+        transition:
+          box-shadow 420ms ease,
+          opacity 420ms ease;
+      }
+
+      .og7-cockpit-sync-band {
+        background: linear-gradient(
+          90deg,
+          transparent,
+          var(--og7-cockpit-band),
+          var(--og7-cockpit-accent-strong),
+          var(--og7-cockpit-band),
+          transparent
+        );
+        opacity: 0.9;
+        transition:
+          background 420ms ease,
+          opacity 420ms ease,
+          transform 420ms ease;
+      }
+
+      .og7-radar-sweep {
+        animation: og7-mission-radar-sweep var(--og7-cockpit-sweep-duration) linear infinite;
+        background: conic-gradient(
+          from 0deg,
+          transparent 0deg,
+          transparent 308deg,
+          var(--og7-cockpit-sweep) 332deg,
+          rgba(255, 255, 255, 0.05) 340deg,
+          transparent 360deg
+        );
+        mix-blend-mode: screen;
+        opacity: 0.62;
+        transform-origin: center;
+        transition: opacity 420ms ease;
+        -webkit-mask: radial-gradient(circle at center, transparent 0 18%, black 35%, black 74%, transparent 100%);
+        mask: radial-gradient(circle at center, transparent 0 18%, black 35%, black 74%, transparent 100%);
+      }
+
+      .og7-radar-sweep[data-og7-mode='lock'] {
+        animation:
+          og7-mission-radar-sweep var(--og7-cockpit-sweep-duration) linear infinite,
+          og7-radar-lock-sweep 1.8s ease-in-out infinite;
+      }
+
+      .og7-radar-sweep[data-og7-mode='action'] {
+        animation:
+          og7-mission-radar-sweep calc(var(--og7-cockpit-sweep-duration) * 0.82) linear infinite,
+          og7-radar-action-sweep 1.25s steps(3, end) infinite;
+      }
+
+      .og7-radar-sweep[data-og7-mode='proof'] {
+        animation:
+          og7-mission-radar-sweep calc(var(--og7-cockpit-sweep-duration) * 0.68) linear infinite,
+          og7-radar-proof-sweep 1.45s ease-in-out infinite;
+      }
+
+      @keyframes og7-mission-radar-sweep {
+        from {
+          transform: rotate(0deg);
+        }
+
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @keyframes og7-radar-lock-sweep {
+        0%,
+        100% {
+          opacity: 0.5;
+          filter: saturate(0.9);
+        }
+
+        50% {
+          opacity: 0.74;
+          filter: saturate(1.08);
+        }
+      }
+
+      @keyframes og7-radar-action-sweep {
+        0%,
+        100% {
+          opacity: 0.58;
+          filter: brightness(0.94);
+        }
+
+        45% {
+          opacity: 0.86;
+          filter: brightness(1.12);
+        }
+      }
+
+      @keyframes og7-radar-proof-sweep {
+        0%,
+        100% {
+          opacity: 0.6;
+          filter: saturate(0.95) brightness(0.98);
+        }
+
+        40% {
+          opacity: 0.92;
+          filter: saturate(1.18) brightness(1.08);
+        }
+      }
+
+      .og7-radar-trail-line {
+        transition:
+          opacity 360ms ease,
+          stroke-width 360ms ease,
+          filter 360ms ease,
+          stroke-dasharray 360ms ease;
+      }
+
+      .og7-radar-trail-line[data-og7-active='true'] {
+        filter: drop-shadow(0 0 6px var(--og7-cockpit-glow));
+      }
+
+      .og7-radar-trail-line[data-og7-pulse='true'] {
+        animation: og7-radar-trail-pulse 980ms ease-out;
+      }
+
+      .og7-radar-acquisition-ring {
+        transition:
+          opacity 320ms ease,
+          transform 320ms ease,
+          border-color 320ms ease,
+          box-shadow 320ms ease;
+      }
+
+      .og7-radar-acquisition-ring[data-og7-active='true'] {
+        animation: og7-radar-acquisition-spin 5.2s linear infinite;
+      }
+
+      .og7-radar-acquisition-ring[data-og7-pulse='true'] {
+        animation:
+          og7-radar-acquisition-spin 5.2s linear infinite,
+          og7-radar-acquisition-pulse 920ms ease-out;
+      }
+
+      .og7-radar-lock-focus-shell {
+        position: relative;
+      }
+
+      .og7-radar-lock-focus-shell::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        box-shadow: inset 0 0 0 1px transparent;
+        opacity: 0;
+        transition:
+          opacity 280ms ease,
+          box-shadow 280ms ease,
+          transform 280ms ease;
+      }
+
+      .og7-radar-lock-focus-shell[data-og7-lock-focus='true']::after {
+        opacity: 1;
+        box-shadow:
+          inset 0 0 0 1px var(--og7-cockpit-accent-strong),
+          0 0 0 1px color-mix(in srgb, var(--og7-cockpit-accent-strong) 45%, transparent),
+          0 0 34px -18px var(--og7-cockpit-glow);
+      }
+
+      @keyframes og7-radar-trail-pulse {
+        0% {
+          opacity: 0.24;
+          stroke-dashoffset: 18;
+        }
+
+        45% {
+          opacity: 0.96;
+          stroke-dashoffset: 0;
+        }
+
+        100% {
+          opacity: 0.62;
+          stroke-dashoffset: -12;
+        }
+      }
+
+      @keyframes og7-radar-acquisition-spin {
+        from {
+          transform: rotate(0deg) scale(1);
+        }
+
+        to {
+          transform: rotate(360deg) scale(1);
+        }
+      }
+
+      @keyframes og7-radar-acquisition-pulse {
+        0% {
+          opacity: 0.3;
+          transform: scale(0.9);
+        }
+
+        50% {
+          opacity: 0.95;
+          transform: scale(1.05);
+        }
+
+        100% {
+          opacity: 0.78;
+          transform: scale(1);
+        }
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AdminQualityPage implements OnInit {
+export class AdminQualityPage implements OnInit, AfterViewInit {
   private readonly service = inject(AdminQualityMatrixService);
+  private readonly opsService = inject(AdminOpsService);
   private readonly missionDecisionService = inject(AdminQualityMissionDecisionsService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly ngZone = inject(NgZone);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly notifications = injectNotificationStore();
-  private readonly translate = inject(TranslateService);
-  private readonly router = inject(Router);
   private readonly isBrowser = isPlatformBrowser(this.platformId);
+  private aiOpsRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  private liveTickTimer: ReturnType<typeof setInterval> | null = null;
+  private missionHudSectionObserver: IntersectionObserver | null = null;
+  private missionHudSectionPulseTimer: ReturnType<typeof setTimeout> | null = null;
+  private missionHudProofPulseTimer: ReturnType<typeof setTimeout> | null = null;
+  private missionControlPanelFocusTimer: ReturnType<typeof setTimeout> | null = null;
+  private missionControlRadarLockSequence = 0;
+  private pendingMissionControlLockReason: AdminQualityMissionRadarLockReason | null = null;
+  private readonly missionHudSectionOrder: readonly AdminQualityMissionHudSection[] = [
+    'coverage',
+    'mission',
+    'workspace',
+  ];
+
+  @ViewChild('coverageSection') private coverageSection?: ElementRef<HTMLElement>;
+  @ViewChild('missionSection') private missionSection?: ElementRef<HTMLElement>;
+  @ViewChild('workspaceSection') private workspaceSection?: ElementRef<HTMLElement>;
 
   readonly loading = signal(true);
   readonly error = signal<string | null>(null);
@@ -130,7 +466,21 @@ export class AdminQualityPage implements OnInit {
   readonly selectedMissionId = signal<string | null>(null);
   readonly workspaceOpen = signal(false);
   readonly activeWorkspaceSurface = signal<AdminQualityWorkspaceSurface>('delegation');
-  readonly availableCodexQuotaUnits = signal(160);
+  readonly selectedAiProvider = signal<AdminAiProvider>('codex');
+  readonly missionHudExpanded = signal(true);
+  readonly missionHudActiveSection = signal<AdminQualityMissionHudSection>('coverage');
+  readonly missionControlFocusedPanel = signal<AdminQualityMissionHudSection | null>(null);
+  readonly missionHudPulsingSection = signal<AdminQualityMissionHudSection | null>(null);
+  readonly missionHudProofPulseActive = signal(false);
+  readonly aiOpsSecurityStatus = signal<AdminQualityAiOpsSyncStatus>('loading');
+  readonly aiOpsSecurity = signal<AdminOpsSecuritySnapshot | null>(null);
+  readonly aiOpsProofStatus = signal<AdminQualityAiOpsSyncStatus>('loading');
+  readonly aiOpsProofs = signal<AdminOpsAiProofSnapshot | null>(null);
+  readonly aiOpsSecurityRefreshing = signal(false);
+  readonly aiOpsSecurityDegraded = signal(false);
+  readonly aiOpsLiveNow = signal(Date.now());
+  readonly aiOpsLastSuccessfulRefreshAt = signal<number | null>(null);
+  readonly aiDispatchingMissionId = signal<string | null>(null);
   readonly missionDecisions = signal<AdminQualityMissionDecisionMap>({});
   readonly missionDecisionSyncStatus = signal<AdminQualityMissionDecisionSyncStatus>('local');
   readonly missionDecisionSyncMessage = signal(
@@ -145,6 +495,470 @@ export class AdminQualityPage implements OnInit {
     'offline',
     'permission',
   ];
+  readonly aiProviders = ADMIN_AI_PROVIDER_OPTIONS;
+  readonly selectedAiProviderOption = computed(() =>
+    resolveAdminAiProviderOption(this.selectedAiProvider()),
+  );
+  readonly selectedAiProviderLabel = computed(() => this.selectedAiProviderOption().label);
+  readonly selectedAiProviderCaption = computed(() => this.selectedAiProviderOption().caption);
+  readonly selectedAiProviderModel = computed(() => this.selectedAiProviderOption().defaultModel);
+  readonly missionHudSectionOptions: readonly {
+    readonly id: AdminQualityMissionHudSection;
+    readonly label: string;
+    readonly shortLabel: string;
+  }[] = [
+    { id: 'coverage', label: 'Coverage matrix', shortLabel: 'Coverage' },
+    { id: 'mission', label: 'Mission Control', shortLabel: 'Mission' },
+    { id: 'workspace', label: 'Workspace deck', shortLabel: 'Workspace' },
+  ];
+  readonly selectedAiOpsModule = computed<AdminQualityAiOpsModule | null>(
+    () =>
+      this.aiOpsSecurity()?.aiKeys.find(
+        (module) => module.provider === this.selectedAiProvider(),
+      ) ?? null,
+  );
+  readonly selectedAiProofModule = computed<AdminQualityAiProofModule | null>(
+    () =>
+      this.aiOpsProofs()?.providers.find(
+        (module) => module.provider === this.selectedAiProvider(),
+      ) ?? null,
+  );
+  readonly selectedAiDispatchReady = computed(() => {
+    const module = this.selectedAiOpsModule();
+    return Boolean(module?.dispatchEnabled && module.keyInserted && module.state === 'ready');
+  });
+  readonly selectedAiDispatchStatusLabel = computed(() => {
+    if (this.aiOpsSecurityStatus() === 'loading') {
+      return 'Verification Ops...';
+    }
+    if (this.aiOpsSecurityStatus() === 'unavailable') {
+      return 'Ops indisponible';
+    }
+
+    const module = this.selectedAiOpsModule();
+    if (!module) {
+      return 'Module non detecte';
+    }
+    if (module.state === 'unsupported') {
+      return 'Module non supporte';
+    }
+    if (!module.keyInserted) {
+      return 'Cle manquante';
+    }
+    if (!module.dispatchEnabled) {
+      return 'Dispatch desactive';
+    }
+    return 'Ops pret';
+  });
+  readonly selectedAiDispatchStatusDetail = computed(() => {
+    if (this.aiOpsSecurityStatus() === 'loading') {
+      return 'Lecture du cockpit Ops avant lancement.';
+    }
+    if (this.aiOpsSecurityStatus() === 'unavailable') {
+      return 'Impossible de verifier /api/admin/ops/security depuis cette session.';
+    }
+
+    const module = this.selectedAiOpsModule();
+    if (!module) {
+      return 'Aucun module Ops ne correspond au provider selectionne.';
+    }
+
+    return `${module.note} Workflow: ${module.workflow}.`;
+  });
+  readonly selectedAiDispatchWorkflow = computed(
+    () => this.selectedAiOpsModule()?.workflow ?? 'workflow non detecte',
+  );
+  readonly selectedAiDispatching = computed(
+    () => this.aiDispatchingMissionId() === this.selectedMission()?.id,
+  );
+  readonly selectedAiProofDisplay = computed<AdminQualityMissionProofDisplay | null>(() => {
+    const proof = this.selectedAiProofModule();
+    const provider = this.selectedAiProviderLabel();
+
+    if (!proof) {
+      return {
+        state: 'unavailable',
+        label: `${provider} proof feed unavailable`,
+        summary: 'No GitHub workflow proof has been observed for the active provider yet.',
+        detail: 'Waiting for the first workflow run to surface a real proof package.',
+        artifactCount: 0,
+        artifactLabel: '0 artifact(s)',
+        runLabel: 'No workflow run detected',
+        runUrl: null,
+        pullRequestLabel: 'No pull request detected',
+        pullRequestUrl: null,
+      };
+    }
+
+    const runNumber =
+      proof.run?.number != null ? `Run #${proof.run.number}` : 'Latest workflow run';
+    const runMoment = proof.run?.updatedAt
+      ? `Updated ${this.formatAiTelemetryRelative(new Date(proof.run.updatedAt).getTime())}.`
+      : `Watching ${proof.workflow}.`;
+    const pullRequestLabel = proof.pullRequest
+      ? `PR #${proof.pullRequest.number ?? 'n/a'} · ${proof.pullRequest.title}`
+      : 'No pull request detected';
+
+    return {
+      state: proof.state,
+      label: this.aiProofStateLabel(proof.state),
+      summary: proof.summary,
+      detail: runMoment,
+      artifactCount: proof.artifacts.length,
+      artifactLabel: `${proof.artifacts.length} artifact(s)`,
+      runLabel: runNumber,
+      runUrl: proof.run?.url ?? null,
+      pullRequestLabel,
+      pullRequestUrl: proof.pullRequest?.url ?? null,
+    };
+  });
+  readonly aiProviderComparison = computed<readonly AdminQualityMissionProviderComparisonEntry[]>(
+    () =>
+      this.aiProviders.map((providerOption) => {
+        const opsModule =
+          this.aiOpsSecurity()?.aiKeys.find((module) => module.provider === providerOption.id) ??
+          null;
+        const proofModule =
+          this.aiOpsProofs()?.providers.find((module) => module.provider === providerOption.id) ??
+          null;
+        const opsState: AdminQualityMissionProviderComparisonEntry['opsState'] = !opsModule
+          ? 'constrained'
+          : opsModule.state === 'unsupported'
+            ? 'unsupported'
+            : opsModule.dispatchEnabled && opsModule.keyInserted && opsModule.state === 'ready'
+              ? 'armed'
+              : 'constrained';
+
+        return {
+          provider: providerOption.id,
+          label: providerOption.label,
+          selected: providerOption.id === this.selectedAiProvider(),
+          opsState,
+          opsLabel:
+            opsState === 'armed'
+              ? 'Ops armed'
+              : opsState === 'unsupported'
+                ? 'Unsupported'
+                : 'Ops constrained',
+          opsDetail: opsModule?.note ?? 'No Ops module detected for this provider.',
+          workflow: opsModule?.workflow ?? providerOption.id,
+          proofState: proofModule?.state ?? 'unavailable',
+          proofLabel: this.aiProofStateLabel(proofModule?.state ?? 'unavailable'),
+          proofDetail: proofModule?.summary ?? 'No workflow proof package detected yet.',
+          artifactCount: proofModule?.artifacts.length ?? 0,
+          pullRequestLabel: proofModule?.pullRequest
+            ? `PR #${proofModule.pullRequest.number ?? 'n/a'}`
+            : 'No PR yet',
+        };
+      }),
+  );
+  readonly selectedAiTelemetryState = computed<AdminQualityAiTelemetryState>(() => {
+    if (this.aiOpsSecurityStatus() === 'loading' || this.aiOpsSecurityRefreshing()) {
+      return 'syncing';
+    }
+
+    if (!this.aiOpsSecurity()) {
+      return 'offline';
+    }
+
+    const lastRefreshAt = this.aiOpsLastSuccessfulRefreshAt();
+    if (lastRefreshAt == null) {
+      return this.aiOpsSecurityDegraded() ? 'degraded' : 'offline';
+    }
+
+    const ageMs = this.aiOpsLiveNow() - lastRefreshAt;
+    if (this.aiOpsSecurityDegraded() || ageMs > ADMIN_QUALITY_AI_OPS_REFRESH_INTERVAL_MS * 2) {
+      return 'degraded';
+    }
+
+    return 'live';
+  });
+  readonly selectedAiTelemetryLabel = computed(() => {
+    switch (this.selectedAiTelemetryState()) {
+      case 'live':
+        return 'Live pulse nominal';
+      case 'degraded':
+        return 'Telemetry degraded';
+      case 'syncing':
+        return 'Sync in progress';
+      default:
+        return 'Console offline';
+    }
+  });
+  readonly selectedAiTelemetryDetail = computed(() => {
+    const lastRefreshAt = this.aiOpsLastSuccessfulRefreshAt();
+    if (this.selectedAiTelemetryState() === 'offline') {
+      return 'Waiting for Ops security feed.';
+    }
+
+    if (this.selectedAiTelemetryState() === 'syncing') {
+      return lastRefreshAt == null
+        ? 'Bootstrapping the Ops telemetry feed.'
+        : `Last stable sync ${this.formatAiTelemetryRelative(lastRefreshAt)}.`;
+    }
+
+    if (lastRefreshAt == null) {
+      return 'Awaiting refresh cadence.';
+    }
+
+    return `Last sync ${this.formatAiTelemetryRelative(lastRefreshAt)}. Next sweep in ${this.aiOpsRefreshCountdownSeconds()}s.`;
+  });
+  readonly missionHudSectionLabel = computed(() => {
+    const section = this.missionHudSectionOptions.find(
+      (option) => option.id === this.missionHudActiveSection(),
+    );
+    return section?.label ?? 'Coverage matrix';
+  });
+  readonly missionHudCompactSummary = computed(() => {
+    const proof = this.selectedAiProofDisplay();
+    return [
+      this.selectedAiDispatchStatusLabel(),
+      this.selectedAiTelemetryLabel(),
+      proof?.label ?? 'Proof unavailable',
+    ].join(' · ');
+  });
+  readonly missionCockpitToneKey = computed(() => this.selectedAiProvider());
+  readonly missionCockpitStyleVars = computed<Record<string, string>>(() => {
+    switch (this.selectedAiProvider()) {
+      case 'claude':
+        return {
+          '--og7-cockpit-accent': 'rgba(251, 191, 36, 0.22)',
+          '--og7-cockpit-accent-strong': 'rgba(251, 191, 36, 0.42)',
+          '--og7-cockpit-secondary': 'rgba(251, 146, 60, 0.18)',
+          '--og7-cockpit-outline': 'rgba(251, 191, 36, 0.2)',
+          '--og7-cockpit-glow': 'rgba(251, 191, 36, 0.28)',
+          '--og7-cockpit-sweep': 'rgba(253, 224, 71, 0.38)',
+          '--og7-cockpit-band': 'rgba(251, 146, 60, 0.24)',
+          '--og7-cockpit-sweep-duration': this.resolveMissionRadarSweepDuration(),
+        };
+      case 'gemini':
+        return {
+          '--og7-cockpit-accent': 'rgba(163, 230, 53, 0.2)',
+          '--og7-cockpit-accent-strong': 'rgba(163, 230, 53, 0.4)',
+          '--og7-cockpit-secondary': 'rgba(34, 197, 94, 0.16)',
+          '--og7-cockpit-outline': 'rgba(163, 230, 53, 0.18)',
+          '--og7-cockpit-glow': 'rgba(132, 204, 22, 0.26)',
+          '--og7-cockpit-sweep': 'rgba(190, 242, 100, 0.34)',
+          '--og7-cockpit-band': 'rgba(74, 222, 128, 0.22)',
+          '--og7-cockpit-sweep-duration': this.resolveMissionRadarSweepDuration(),
+        };
+      case 'copilot':
+        return {
+          '--og7-cockpit-accent': 'rgba(96, 165, 250, 0.2)',
+          '--og7-cockpit-accent-strong': 'rgba(96, 165, 250, 0.4)',
+          '--og7-cockpit-secondary': 'rgba(59, 130, 246, 0.16)',
+          '--og7-cockpit-outline': 'rgba(96, 165, 250, 0.18)',
+          '--og7-cockpit-glow': 'rgba(59, 130, 246, 0.24)',
+          '--og7-cockpit-sweep': 'rgba(147, 197, 253, 0.32)',
+          '--og7-cockpit-band': 'rgba(96, 165, 250, 0.22)',
+          '--og7-cockpit-sweep-duration': this.resolveMissionRadarSweepDuration(),
+        };
+      default:
+        return {
+          '--og7-cockpit-accent': 'rgba(34, 211, 238, 0.2)',
+          '--og7-cockpit-accent-strong': 'rgba(34, 211, 238, 0.42)',
+          '--og7-cockpit-secondary': 'rgba(56, 189, 248, 0.16)',
+          '--og7-cockpit-outline': 'rgba(34, 211, 238, 0.18)',
+          '--og7-cockpit-glow': 'rgba(34, 211, 238, 0.26)',
+          '--og7-cockpit-sweep': 'rgba(103, 232, 249, 0.38)',
+          '--og7-cockpit-band': 'rgba(56, 189, 248, 0.22)',
+          '--og7-cockpit-sweep-duration': this.resolveMissionRadarSweepDuration(),
+        };
+    }
+  });
+  readonly missionControlRadarLatestSignal = computed<AdminQualityMissionRadarLockDisplayEntry | null>(
+    () => this.missionControlRadarLockLog()[0] ?? null,
+  );
+  readonly missionControlShellStyleVars = computed<Record<string, string>>(() => ({
+    ...this.missionCockpitStyleVars(),
+    ...this.missionControlRadarSignalStyleVars(this.missionControlRadarLatestSignal()?.signalTone ?? null),
+  }));
+  readonly missionControlRadarEchoPoints = computed<
+    readonly AdminQualityMissionRadarEchoPoint[]
+  >(() => {
+    const positions: Record<
+      AdminQualityMissionHudSection,
+      { leftPercent: number; topPercent: number }
+    > = {
+      coverage: { leftPercent: 18, topPercent: 28 },
+      mission: { leftPercent: 66, topPercent: 36 },
+      workspace: { leftPercent: 34, topPercent: 76 },
+    };
+
+    const coverageCount = this.filteredEntries().length;
+    const missionTaskCount = this.selectedMissionTasks().length;
+    const workspaceCount = this.selectedWorkspaceCount();
+    const metrics: Record<
+      AdminQualityMissionHudSection,
+      { count: number; total: number; metricLabel: string; intensity: AdminQualityMissionRadarEchoIntensity }
+    > = {
+      coverage: {
+        count: coverageCount,
+        total: this.totalDomains(),
+        metricLabel: `${coverageCount}/${this.totalDomains()}`,
+        intensity: this.resolveRadarEchoIntensity(coverageCount, this.totalDomains(), 8, 0.75, 3, 0.35),
+      },
+      mission: {
+        count: missionTaskCount,
+        total: Math.max(missionTaskCount, 1),
+        metricLabel: `${missionTaskCount} task(s)`,
+        intensity:
+          this.selectedMissionRequiredUnits() >= 50 || missionTaskCount >= 6
+            ? 'high'
+            : this.selectedMissionRequiredUnits() >= 20 || missionTaskCount >= 3
+              ? 'medium'
+              : 'low',
+      },
+      workspace: {
+        count: workspaceCount,
+        total: Math.max(this.selectedEntryActions().length, 1),
+        metricLabel: `${workspaceCount} surface(s)`,
+        intensity: this.resolveRadarEchoIntensity(
+          workspaceCount,
+          Math.max(this.selectedEntryActions().length, 1),
+          3,
+          0.75,
+          2,
+          0.4,
+        ),
+      },
+    };
+
+    return this.missionHudSectionOptions.map((section) => ({
+      id: section.id,
+      label: section.label,
+      shortLabel: section.shortLabel,
+      metricLabel: metrics[section.id].metricLabel,
+      leftPercent: positions[section.id].leftPercent,
+      topPercent: positions[section.id].topPercent,
+      left: `${positions[section.id].leftPercent}%`,
+      top: `${positions[section.id].topPercent}%`,
+      intensity: metrics[section.id].intensity,
+      active: this.missionHudActiveSection() === section.id,
+      pulsing: this.missionHudSectionPulse(section.id),
+    }));
+  });
+  readonly missionControlActiveRadarEchoPoint = computed<AdminQualityMissionRadarEchoPoint | null>(
+    () => this.missionControlRadarEchoPoints().find((point) => point.active) ?? null,
+  );
+  readonly missionControlRadarLockHistory = signal<
+    readonly AdminQualityMissionRadarLockHistoryEntry[]
+  >([]);
+  readonly missionControlProofStreamIntensity = computed<AdminQualityMissionRadarEchoIntensity>(() => {
+    const proof = this.selectedAiProofDisplay();
+    if (!proof) {
+      return 'low';
+    }
+
+    if (
+      (proof.state === 'completed' && proof.artifactCount >= 2) ||
+      (proof.state === 'in-progress' && proof.artifactCount >= 1)
+    ) {
+      return 'high';
+    }
+
+    if (
+      proof.state === 'in-progress' ||
+      proof.state === 'completed' ||
+      proof.state === 'queued' ||
+      proof.artifactCount >= 1
+    ) {
+      return 'medium';
+    }
+
+    return 'low';
+  });
+  readonly missionControlRadarLockLog = computed<readonly AdminQualityMissionRadarLockDisplayEntry[]>(() => {
+    const points = this.missionControlRadarEchoPoints();
+    const proofStream = this.missionControlProofStreamIntensity();
+
+    return this.missionControlRadarLockHistory().map((entry) => {
+      const point = points.find((candidate) => candidate.id === entry.id);
+      const fallback = this.missionHudSectionOptions.find((option) => option.id === entry.id);
+
+      return {
+        ...entry,
+        label: point?.label ?? fallback?.label ?? 'Unknown sector',
+        metricLabel: point?.metricLabel ?? 'No metric',
+        proofStream,
+        reasonLabel: this.missionControlTimelineReasonLabel(entry),
+        kindLabel: this.missionControlTimelineKindLabel(entry.kind),
+        signalTone: this.missionControlTimelineSignalTone(entry),
+        detailLabel:
+          entry.detailLabel ??
+          (point?.label || fallback?.label ? `${entry.stateLabel} ${point?.label ?? fallback?.label}` : entry.stateLabel),
+      };
+    });
+  });
+  readonly missionControlContactLockLabel = computed(() => {
+    const point = this.missionControlActiveRadarEchoPoint();
+    if (!point) {
+      return 'Contact lock unavailable';
+    }
+
+    return point.pulsing ? `Acquiring ${point.label}` : `Contact lock · ${point.label}`;
+  });
+  readonly missionControlContactLockDetail = computed(() => {
+    const point = this.missionControlActiveRadarEchoPoint();
+    if (!point) {
+      return 'No active section tracked by mission radar.';
+    }
+
+    const proofStream = this.missionControlProofStreamIntensity();
+    return `${point.metricLabel} · proof stream ${proofStream}`;
+  });
+  readonly missionHudAmbientTone = computed<AdminQualityMissionHudAmbientTone>(() => {
+    const proof = this.selectedAiProofDisplay();
+    const telemetry = this.selectedAiTelemetryState();
+    const missionStatus = this.selectedMission()?.status ?? 'proposed';
+
+    if (missionStatus === 'blocked' || missionStatus === 'rejected' || proof?.state === 'failed') {
+      return 'critical';
+    }
+
+    if (telemetry === 'syncing' || proof?.state === 'in-progress') {
+      return 'syncing';
+    }
+
+    if (telemetry === 'degraded' || telemetry === 'offline' || !this.selectedAiDispatchReady()) {
+      return 'warning';
+    }
+
+    return 'nominal';
+  });
+  readonly missionHudEnergyLaneSegments = computed<readonly AdminQualityMissionHudLaneSegment[]>(
+    () => {
+      const mission = this.selectedMission();
+      const proof = this.selectedAiProofDisplay();
+      const dispatchState = this.resolveMissionHudLaneState(
+        mission?.status ?? 'proposed',
+        this.selectedAiDispatchReady(),
+        false,
+      );
+      const proofState = this.resolveMissionHudLaneState(
+        mission?.status ?? 'proposed',
+        this.selectedAiDispatchReady(),
+        true,
+      );
+      const validationState: AdminQualityMissionHudLaneState =
+        mission?.status === 'done'
+          ? 'flowing'
+          : mission?.status === 'proof-returned'
+            ? 'charged'
+            : proof?.state === 'failed'
+              ? 'fault'
+              : 'standby';
+
+      return [
+        { id: 'mission-dispatch', from: 'Mission', to: 'Dispatch', state: dispatchState },
+        { id: 'dispatch-proof', from: 'Dispatch', to: 'Proof', state: proofState },
+        { id: 'proof-validation', from: 'Proof', to: 'Validation', state: validationState },
+      ];
+    },
+  );
+  readonly availableCodexQuotaUnits = computed(() =>
+    this.selectedAiDispatchReady() ? this.selectedMissionRequiredUnits() : 0,
+  );
 
   readonly entries = computed(() => this.snapshot()?.entries ?? []);
   readonly matrixSourceStatus = computed<AdminQualityMatrixSourceStatus | null>(
@@ -433,12 +1247,15 @@ export class AdminQualityPage implements OnInit {
     const difficulty = this.selectedDelegation()?.difficulty;
     return mission && difficulty ? buildMissionTasks(mission, difficulty) : [];
   });
+  readonly selectedMissionRequiredUnits = computed(() =>
+    this.selectedMissionTasks().reduce((sum, task) => sum + task.estimatedUnits, 0),
+  );
   readonly selectedMissionQuotaSummary = computed<AdminQualityMissionQuotaSummary | null>(() => {
     const tasks = this.selectedMissionTasks();
     return tasks.length ? summarizeMissionQuota(tasks, this.availableCodexQuotaUnits()) : null;
   });
   readonly canStartSelectedMission = computed(
-    () => this.selectedMissionQuotaSummary()?.sufficient ?? false,
+    () => this.selectedAiDispatchReady() && !this.selectedAiDispatching(),
   );
 
   constructor() {
@@ -449,14 +1266,75 @@ export class AdminQualityPage implements OnInit {
     effect(() => {
       this.persistViewState();
     });
+
+    let previousSection: AdminQualityMissionHudSection | null = null;
+    effect(() => {
+      const currentSection = this.missionHudActiveSection();
+      const lockReason = this.pendingMissionControlLockReason ?? 'section-pulse';
+      if (previousSection === null) {
+        this.recordMissionControlLock(currentSection, 'Locked', lockReason);
+      } else if (previousSection !== currentSection) {
+        this.triggerMissionHudSectionPulse(currentSection);
+        this.recordMissionControlLock(currentSection, 'Acquiring', lockReason);
+      }
+      this.pendingMissionControlLockReason = null;
+      previousSection = currentSection;
+    });
+
+    let previousProofSignature: string | null = null;
+    effect(() => {
+      const proof = this.selectedAiProofDisplay();
+      const signature = proof
+        ? `${proof.state}:${proof.runLabel}:${proof.artifactCount}:${proof.pullRequestLabel}`
+        : 'none';
+
+      if (
+        signature !== previousProofSignature &&
+        proof &&
+        (proof.state === 'completed' || proof.state === 'in-progress')
+      ) {
+        this.triggerMissionHudProofPulse();
+        if (previousProofSignature !== null) {
+          this.recordMissionControlProofEvent(this.missionHudActiveSection(), proof.label);
+        }
+      }
+
+      previousProofSignature = signature;
+    });
   }
 
   ngOnInit(): void {
     this.restoreViewState();
     this.restoreMissionDecisions();
     this.loadMissionDecisionsFromServer();
+    this.loadAiDispatchReadiness(false);
     this.viewStateReady.set(true);
-    this.destroyRef.onDestroy(() => this.stopMissionVoice(false));
+    this.ngZone.runOutsideAngular(() => {
+      this.aiOpsRefreshTimer = setInterval(
+        () => this.ngZone.run(() => this.loadAiDispatchReadiness(true)),
+        ADMIN_QUALITY_AI_OPS_REFRESH_INTERVAL_MS,
+      );
+      this.liveTickTimer = setInterval(
+        () => this.ngZone.run(() => this.aiOpsLiveNow.set(Date.now())),
+        ADMIN_QUALITY_LIVE_TICK_INTERVAL_MS,
+      );
+    });
+    this.destroyRef.onDestroy(() => {
+      this.stopMissionVoice(false);
+      if (this.aiOpsRefreshTimer) {
+        clearInterval(this.aiOpsRefreshTimer);
+      }
+      if (this.liveTickTimer) {
+        clearInterval(this.liveTickTimer);
+      }
+      this.missionHudSectionObserver?.disconnect();
+      if (this.missionHudSectionPulseTimer) {
+        clearTimeout(this.missionHudSectionPulseTimer);
+      }
+      if (this.missionHudProofPulseTimer) {
+        clearTimeout(this.missionHudProofPulseTimer);
+      }
+    });
 
     this.service
       .loadMatrix()
@@ -472,6 +1350,10 @@ export class AdminQualityPage implements OnInit {
           this.loading.set(false);
         },
       });
+  }
+
+  ngAfterViewInit(): void {
+    this.registerMissionHudScrollSpy();
   }
 
   setSearch(event: Event): void {
@@ -509,6 +1391,16 @@ export class AdminQualityPage implements OnInit {
       ((event.target as HTMLSelectElement | null)
         ?.value as FilterValue<AdminQualityMatrixBucket>) ?? 'all',
     );
+  }
+
+  setAiProvider(event: Event): void {
+    this.stopVoiceForContextChange();
+    const value = (event.target as HTMLSelectElement | null)?.value;
+    if (!isAdminAiProvider(value)) {
+      return;
+    }
+
+    this.selectedAiProvider.set(value);
   }
 
   resetFilters(): void {
@@ -551,6 +1443,7 @@ export class AdminQualityPage implements OnInit {
     this.stopVoiceForContextChange();
     this.activeWorkspaceSurface.set(surface);
     this.workspaceOpen.set(true);
+    this.setMissionHudSection('workspace', 'manual-targeting');
   }
 
   closeWorkspace(): void {
@@ -562,52 +1455,61 @@ export class AdminQualityPage implements OnInit {
     this.activeWorkspaceSurface.set(surface);
   }
 
-  setAvailableCodexQuotaUnits(event: Event): void {
-    const nextValue = Number(
-      (event.target as HTMLInputElement | null)?.value ?? this.availableCodexQuotaUnits(),
-    );
-    if (!Number.isFinite(nextValue)) {
+  toggleMissionHud(): void {
+    this.missionHudExpanded.update((value) => !value);
+  }
+
+  setMissionHudSection(
+    section: AdminQualityMissionHudSection,
+    reason: AdminQualityMissionRadarLockReason = 'manual-targeting',
+  ): void {
+    this.pendingMissionControlLockReason = reason;
+    this.missionHudActiveSection.set(section);
+  }
+
+  scrollMissionHudToSection(section: AdminQualityMissionHudSection): void {
+    this.setMissionHudSection(section, 'manual-targeting');
+
+    if (!this.isBrowser) {
       return;
     }
 
-    this.availableCodexQuotaUnits.set(Math.max(0, Math.round(nextValue)));
+    const element = this.resolveMissionHudSectionElement(section)?.nativeElement;
+    if (element && typeof element.scrollIntoView === 'function') {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  focusMissionControlLockEntry(section: AdminQualityMissionHudSection): void {
+    if (section === 'workspace') {
+      this.openWorkspace();
+      return;
+    }
+
+    this.scrollMissionHudToSection(section);
   }
 
   handleMissionAction(event: AdminQualityMissionControlActionEvent): void {
     const launchesDelegation = event.action === 'auto-delegate';
-
-    if (launchesDelegation) {
-      const quotaSummary = this.quotaSummaryForMission(event.recommendation);
-      if (!quotaSummary.sufficient) {
-        this.notifications.error(
-          this.translate.instant('admin.quality.codex.notifications.insufficientQuota', {
-            required: quotaSummary.requiredUnits,
-            available: quotaSummary.availableUnits,
-            missing: quotaSummary.shortageUnits,
-          }),
-          { source: 'admin-quality' },
-        );
-        return;
-      }
-    }
-
     const resolution = resolveMissionAction(event.action, event.recommendation);
     if (!resolution) {
       return;
     }
 
     this.stopVoiceForContextChange();
+    this.recordMissionControlAction(event);
 
     if (resolution.kind === 'reset') {
       this.resetMission(event.recommendation, resolution.message);
       return;
     }
 
-    this.updateMissionStatus(event.recommendation, resolution.status, resolution.message);
-
     if (launchesDelegation && resolution.status === 'in-progress') {
-      void this.openCodexOpsPrefill(event.recommendation);
+      this.dispatchSelectedMission(event.recommendation, resolution.message);
+      return;
     }
+
+    this.updateMissionStatus(event.recommendation, resolution.status, resolution.message);
   }
 
   matrixSourceLabel(status: AdminQualityMatrixSourceStatus): string {
@@ -655,6 +1557,581 @@ export class AdminQualityPage implements OnInit {
         return 'border-amber-300/25 bg-amber-400/12 text-amber-100';
       default:
         return 'border-white/12 bg-white/[0.05] text-slate-100';
+    }
+  }
+
+  missionHudStatusLabel(status: AdminQualityMissionStatus): string {
+    switch (status) {
+      case 'approved':
+        return 'Prete';
+      case 'in-progress':
+        return 'En execution';
+      case 'proof-returned':
+        return 'Preuve revenue';
+      case 'done':
+        return 'Validee';
+      case 'deferred':
+        return 'Differee';
+      case 'rejected':
+        return 'Rejetee';
+      case 'blocked':
+        return 'Bloquee';
+      default:
+        return 'En attente';
+    }
+  }
+
+  missionHudStatusClasses(status: AdminQualityMissionStatus): string {
+    switch (status) {
+      case 'approved':
+        return 'border-sky-400/25 bg-sky-400/12 text-sky-100';
+      case 'in-progress':
+        return 'border-emerald-400/25 bg-emerald-400/12 text-emerald-100';
+      case 'proof-returned':
+        return 'border-amber-400/25 bg-amber-400/12 text-amber-100';
+      case 'done':
+      case 'deferred':
+        return 'border-white/12 bg-white/5 text-slate-100';
+      case 'rejected':
+      case 'blocked':
+        return 'border-rose-400/25 bg-rose-400/12 text-rose-100';
+      default:
+        return 'border-violet-400/25 bg-violet-400/12 text-violet-100';
+    }
+  }
+
+  missionHudTelemetryClasses(status: AdminQualityAiTelemetryState): string {
+    switch (status) {
+      case 'live':
+        return 'border-emerald-400/25 bg-emerald-400/12 text-emerald-100';
+      case 'degraded':
+        return 'border-amber-400/25 bg-amber-400/12 text-amber-100';
+      case 'syncing':
+        return 'border-sky-400/25 bg-sky-400/12 text-sky-100';
+      default:
+        return 'border-white/12 bg-white/5 text-slate-200';
+    }
+  }
+
+  missionHudProofClasses(state: AdminQualityMissionProofDisplay['state']): string {
+    switch (state) {
+      case 'completed':
+        return 'border-emerald-400/25 bg-emerald-400/12 text-emerald-100';
+      case 'in-progress':
+        return 'border-sky-400/25 bg-sky-400/12 text-sky-100';
+      case 'queued':
+        return 'border-amber-400/25 bg-amber-400/12 text-amber-100';
+      case 'failed':
+        return 'border-rose-400/25 bg-rose-400/12 text-rose-100';
+      default:
+        return 'border-white/12 bg-white/5 text-slate-200';
+    }
+  }
+
+  missionHudOpsClasses(): string {
+    return this.selectedAiDispatchReady()
+      ? 'border-emerald-400/25 bg-emerald-400/12 text-emerald-100'
+      : 'border-amber-400/25 bg-amber-400/12 text-amber-100';
+  }
+
+  missionHudSectionClasses(section: AdminQualityMissionHudSection): string {
+    if (this.missionHudActiveSection() === section) {
+      return this.missionHudSectionPulse(section)
+        ? 'border-cyan-300/45 bg-cyan-400/18 text-cyan-100 shadow-[0_0_0_1px_rgba(34,211,238,0.18),0_0_22px_rgba(34,211,238,0.18)] animate-pulse'
+        : 'border-cyan-300/35 bg-cyan-400/14 text-cyan-100 shadow-[0_0_0_1px_rgba(34,211,238,0.12)]';
+    }
+
+    return 'border-white/10 bg-white/5 text-slate-300 hover:bg-white/8';
+  }
+
+  missionHudAmbientOverlayClasses(): string {
+    switch (this.missionHudAmbientTone()) {
+      case 'critical':
+        return 'bg-[radial-gradient(circle_at_top_right,_rgba(251,113,133,0.22),_transparent_26%),radial-gradient(circle_at_14%_18%,_rgba(251,191,36,0.12),_transparent_18%),linear-gradient(135deg,rgba(127,29,29,0.12),transparent_55%)]';
+      case 'syncing':
+        return 'bg-[radial-gradient(circle_at_top_right,_rgba(56,189,248,0.2),_transparent_24%),radial-gradient(circle_at_18%_18%,_rgba(125,211,252,0.16),_transparent_22%),linear-gradient(135deg,rgba(14,116,144,0.14),transparent_55%)] animate-pulse';
+      case 'warning':
+        return 'bg-[radial-gradient(circle_at_top_right,_rgba(251,191,36,0.18),_transparent_24%),radial-gradient(circle_at_18%_18%,_rgba(56,189,248,0.1),_transparent_18%),linear-gradient(135deg,rgba(120,53,15,0.12),transparent_55%)]';
+      default:
+        return 'bg-[radial-gradient(circle_at_top_right,_rgba(34,211,238,0.18),_transparent_24%),radial-gradient(circle_at_18%_18%,_rgba(16,185,129,0.1),_transparent_18%),linear-gradient(135deg,rgba(8,47,73,0.18),transparent_58%)]';
+    }
+  }
+
+  missionHudProofPulse(state: AdminQualityMissionProofDisplay['state']): boolean {
+    return this.missionHudProofPulseActive() && (state === 'completed' || state === 'in-progress');
+  }
+
+  missionHudSectionPulse(section: AdminQualityMissionHudSection): boolean {
+    return this.missionHudPulsingSection() === section;
+  }
+
+  missionControlShellClasses(): string {
+    switch (this.selectedAiProvider()) {
+      case 'claude':
+        return 'border-amber-300/25 bg-[linear-gradient(180deg,rgba(28,14,7,0.92),rgba(21,10,8,0.9))] shadow-[0_34px_90px_-58px_rgba(251,191,36,0.42)]';
+      case 'gemini':
+        return 'border-lime-300/20 bg-[linear-gradient(180deg,rgba(18,22,7,0.92),rgba(9,16,14,0.9))] shadow-[0_34px_90px_-58px_rgba(132,204,22,0.36)]';
+      case 'copilot':
+        return 'border-blue-300/20 bg-[linear-gradient(180deg,rgba(8,16,34,0.92),rgba(8,14,26,0.9))] shadow-[0_34px_90px_-58px_rgba(96,165,250,0.34)]';
+      default:
+        return 'border-cyan-300/20 bg-[linear-gradient(180deg,rgba(4,14,30,0.92),rgba(6,16,28,0.9))] shadow-[0_34px_90px_-58px_rgba(34,211,238,0.34)]';
+    }
+  }
+
+  missionControlRadarClasses(): string {
+    const tone = this.missionHudAmbientTone();
+
+    switch (this.selectedAiProvider()) {
+      case 'claude':
+        return tone === 'critical'
+          ? 'bg-[radial-gradient(circle_at_20%_24%,_rgba(251,113,133,0.24),_transparent_20%),radial-gradient(circle_at_80%_22%,_rgba(251,191,36,0.2),_transparent_22%),repeating-radial-gradient(circle_at_center,_rgba(251,191,36,0.14)_0,_rgba(251,191,36,0.14)_2px,_transparent_2px,_transparent_42px)]'
+          : 'bg-[radial-gradient(circle_at_20%_24%,_rgba(251,191,36,0.22),_transparent_20%),radial-gradient(circle_at_80%_22%,_rgba(251,146,60,0.16),_transparent_22%),repeating-radial-gradient(circle_at_center,_rgba(251,191,36,0.12)_0,_rgba(251,191,36,0.12)_2px,_transparent_2px,_transparent_42px)]';
+      case 'gemini':
+        return tone === 'critical'
+          ? 'bg-[radial-gradient(circle_at_18%_26%,_rgba(248,113,113,0.2),_transparent_18%),radial-gradient(circle_at_82%_24%,_rgba(132,204,22,0.16),_transparent_20%),repeating-radial-gradient(circle_at_center,_rgba(163,230,53,0.12)_0,_rgba(163,230,53,0.12)_2px,_transparent_2px,_transparent_40px)]'
+          : 'bg-[radial-gradient(circle_at_18%_26%,_rgba(163,230,53,0.18),_transparent_18%),radial-gradient(circle_at_82%_24%,_rgba(34,197,94,0.14),_transparent_20%),repeating-radial-gradient(circle_at_center,_rgba(163,230,53,0.12)_0,_rgba(163,230,53,0.12)_2px,_transparent_2px,_transparent_40px)]';
+      case 'copilot':
+        return tone === 'critical'
+          ? 'bg-[radial-gradient(circle_at_18%_22%,_rgba(248,113,113,0.2),_transparent_18%),radial-gradient(circle_at_82%_18%,_rgba(96,165,250,0.18),_transparent_20%),linear-gradient(135deg,rgba(59,130,246,0.1)_0%,transparent_48%,rgba(96,165,250,0.1)_100%)]'
+          : 'bg-[radial-gradient(circle_at_18%_22%,_rgba(96,165,250,0.18),_transparent_18%),radial-gradient(circle_at_82%_18%,_rgba(59,130,246,0.14),_transparent_20%),linear-gradient(135deg,rgba(59,130,246,0.1)_0%,transparent_48%,rgba(96,165,250,0.1)_100%)]';
+      default:
+        return tone === 'critical'
+          ? 'bg-[radial-gradient(circle_at_18%_22%,_rgba(248,113,113,0.2),_transparent_18%),radial-gradient(circle_at_82%_18%,_rgba(34,211,238,0.16),_transparent_20%),repeating-radial-gradient(circle_at_center,_rgba(34,211,238,0.1)_0,_rgba(34,211,238,0.1)_2px,_transparent_2px,_transparent_38px)]'
+          : 'bg-[radial-gradient(circle_at_18%_22%,_rgba(34,211,238,0.18),_transparent_18%),radial-gradient(circle_at_82%_18%,_rgba(56,189,248,0.14),_transparent_20%),repeating-radial-gradient(circle_at_center,_rgba(34,211,238,0.1)_0,_rgba(34,211,238,0.1)_2px,_transparent_2px,_transparent_38px)]';
+    }
+  }
+
+  missionControlProviderLightClasses(): string {
+    switch (this.selectedAiProvider()) {
+      case 'claude':
+        return 'bg-[linear-gradient(90deg,transparent,rgba(251,191,36,0.18),rgba(251,146,60,0.2),transparent)]';
+      case 'gemini':
+        return 'bg-[linear-gradient(90deg,transparent,rgba(163,230,53,0.16),rgba(34,197,94,0.18),transparent)]';
+      case 'copilot':
+        return 'bg-[linear-gradient(90deg,transparent,rgba(96,165,250,0.16),rgba(59,130,246,0.18),transparent)]';
+      default:
+        return 'bg-[linear-gradient(90deg,transparent,rgba(34,211,238,0.16),rgba(56,189,248,0.18),transparent)]';
+    }
+  }
+
+  missionControlProviderSignatureLabel(): string {
+    switch (this.selectedAiProvider()) {
+      case 'claude':
+        return 'Claude ember line';
+      case 'gemini':
+        return 'Gemini solar mesh';
+      case 'copilot':
+        return 'Copilot cobalt grid';
+      default:
+        return 'Codex spectrum';
+    }
+  }
+
+  missionControlProviderSignatureClasses(): string {
+    switch (this.selectedAiProvider()) {
+      case 'claude':
+        return 'border-amber-300/25 bg-amber-400/12 text-amber-100';
+      case 'gemini':
+        return 'border-lime-300/25 bg-lime-400/12 text-lime-100';
+      case 'copilot':
+        return 'border-blue-300/25 bg-blue-400/12 text-blue-100';
+      default:
+        return 'border-cyan-300/25 bg-cyan-400/12 text-cyan-100';
+    }
+  }
+
+  missionControlRadarEchoClasses(point: AdminQualityMissionRadarEchoPoint): string {
+    if (point.active) {
+      return point.pulsing
+        ? 'border-white/40 bg-white/18 text-white shadow-[0_0_0_1px_var(--og7-cockpit-accent-strong),0_0_22px_var(--og7-cockpit-glow)] animate-pulse'
+        : 'border-white/30 bg-white/14 text-white shadow-[0_0_0_1px_var(--og7-cockpit-accent),0_0_18px_var(--og7-cockpit-glow)]';
+    }
+
+    switch (point.intensity) {
+      case 'high':
+        return 'border-white/16 bg-slate-950/55 text-slate-200 hover:border-white/24 hover:bg-white/10';
+      case 'medium':
+        return 'border-white/12 bg-slate-950/45 text-slate-300 hover:border-white/20 hover:bg-white/8';
+      default:
+        return 'border-white/10 bg-slate-950/35 text-slate-400 hover:border-white/16 hover:bg-white/7';
+    }
+  }
+
+  missionControlRadarEchoRingClasses(point: AdminQualityMissionRadarEchoPoint): string {
+    if (point.active) {
+      return point.pulsing
+        ? 'border-[var(--og7-cockpit-accent-strong)] opacity-100 scale-100 animate-ping'
+        : 'border-[var(--og7-cockpit-accent)] opacity-90 scale-100';
+    }
+
+    return 'border-white/10 opacity-60 scale-95';
+  }
+
+  missionControlRadarEchoLabelClasses(point: AdminQualityMissionRadarEchoPoint): string {
+    return point.active ? 'text-white' : 'text-slate-400';
+  }
+
+  missionControlRadarTrailOpacity(point: AdminQualityMissionRadarEchoPoint): string {
+    if (point.pulsing) {
+      return '0.96';
+    }
+
+    if (point.active) {
+      return point.intensity === 'high' ? '0.7' : point.intensity === 'medium' ? '0.56' : '0.42';
+    }
+
+    return point.intensity === 'high' ? '0.18' : point.intensity === 'medium' ? '0.12' : '0.08';
+  }
+
+  missionControlRadarTrailWidth(point: AdminQualityMissionRadarEchoPoint): string {
+    if (point.pulsing || point.intensity === 'high') {
+      return '2.4';
+    }
+
+    return point.intensity === 'medium' ? '1.8' : '1.3';
+  }
+
+  missionControlRadarTrailDasharray(point: AdminQualityMissionRadarEchoPoint): string {
+    return point.pulsing ? '10 7' : point.active ? '7 6' : '4 8';
+  }
+
+  missionControlRadarTrailEndpointRadius(point: AdminQualityMissionRadarEchoPoint): string {
+    return point.intensity === 'high' ? '4.2' : point.intensity === 'medium' ? '3.4' : '2.8';
+  }
+
+  missionControlRadarMetricClasses(point: AdminQualityMissionRadarEchoPoint): string {
+    if (point.active) {
+      return 'text-white/80';
+    }
+
+    return point.intensity === 'high' ? 'text-slate-200/75' : 'text-slate-400';
+  }
+
+  missionControlContactLockClasses(): string {
+    const point = this.missionControlActiveRadarEchoPoint();
+    if (!point) {
+      return 'border-white/10 bg-white/5 text-slate-300';
+    }
+
+    return point.pulsing
+      ? 'border-[var(--og7-cockpit-accent-strong)] bg-white/12 text-white shadow-[0_0_18px_var(--og7-cockpit-glow)]'
+      : 'border-[var(--og7-cockpit-accent)] bg-white/10 text-slate-100';
+  }
+
+  missionControlContactLogEntryClasses(index: number): string {
+    if (index === 0) {
+      return 'border-[var(--og7-cockpit-accent)] bg-white/10 text-slate-100';
+    }
+
+    if (index === 1) {
+      return 'border-white/10 bg-slate-950/38 text-slate-300 opacity-90';
+    }
+
+    return 'border-white/10 bg-slate-950/28 text-slate-400 opacity-70';
+  }
+
+  missionControlContactLogAge(index: number): 'current' | 'recent' | 'stale' {
+    if (index === 0) {
+      return 'current';
+    }
+
+    return index === 1 ? 'recent' : 'stale';
+  }
+
+  missionControlContactLogTimeClasses(index: number): string {
+    switch (this.missionControlContactLogAge(index)) {
+      case 'recent':
+        return 'border-white/10 bg-slate-950/60 text-slate-300 opacity-85';
+      case 'stale':
+        return 'border-white/8 bg-slate-950/45 text-slate-400 opacity-70';
+      default:
+        return 'border-white/10 bg-slate-950/70 text-slate-200';
+    }
+  }
+
+  missionControlContactLogSignalClasses(signalTone: AdminQualityMissionRadarSignalTone): string {
+    switch (signalTone) {
+      case 'proof':
+      case 'success':
+        return 'border-emerald-400/25 bg-emerald-400/12 text-emerald-100';
+      case 'manual':
+      case 'primary':
+        return 'border-sky-400/25 bg-sky-400/12 text-sky-100';
+      case 'secondary':
+        return 'border-violet-400/25 bg-violet-400/12 text-violet-100';
+      case 'danger':
+        return 'border-rose-400/25 bg-rose-400/12 text-rose-100';
+      case 'neutral':
+        return 'border-white/12 bg-white/5 text-slate-200';
+      default:
+        return 'border-amber-400/25 bg-amber-400/12 text-amber-100';
+    }
+  }
+
+  missionControlPanelFocused(section: AdminQualityMissionHudSection): boolean {
+    return this.missionControlFocusedPanel() === section;
+  }
+
+  missionControlRadarSignalTone(): AdminQualityMissionRadarSignalTone | 'idle' {
+    return this.missionControlRadarLatestSignal()?.signalTone ?? 'idle';
+  }
+
+  missionControlDisplaySignalTone(): AdminQualityMissionRadarSignalTone {
+    const signalTone = this.missionControlRadarSignalTone();
+    return signalTone === 'idle' ? 'pulse' : signalTone;
+  }
+
+  missionControlRadarSweepMode(): AdminQualityMissionRadarTimelineKind | 'idle' {
+    return this.missionControlRadarLatestSignal()?.kind ?? 'idle';
+  }
+
+  missionControlRadarCadenceLabel(): string {
+    const count = this.missionControlRadarLockLog().length;
+    return `${count} ${count === 1 ? 'event' : 'events'} / active cycle`;
+  }
+
+  missionControlRadarCadenceDetail(): string {
+    const entries = this.missionControlRadarLockLog();
+    const lockCount = entries.filter((entry) => entry.kind === 'lock').length;
+    const actionCount = entries.filter((entry) => entry.kind === 'action').length;
+    const proofCount = entries.filter((entry) => entry.kind === 'proof').length;
+
+    return `${lockCount} lock${lockCount > 1 ? 's' : ''} · ${actionCount} action${actionCount > 1 ? 's' : ''} · ${proofCount} proof${proofCount > 1 ? 's' : ''}`;
+  }
+
+  missionControlTimelineSlotLabel(index: number): string {
+    return index === 0 ? 'T+0' : `T-${index}`;
+  }
+
+  missionControlTimelineCadenceLabel(index: number): string {
+    return index === 0 ? 'now' : `${index} hop${index > 1 ? 's' : ''} ago`;
+  }
+
+  private missionControlTimelineKindLabel(kind: AdminQualityMissionRadarTimelineKind): string {
+    switch (kind) {
+      case 'action':
+        return 'Action';
+      case 'proof':
+        return 'Proof';
+      default:
+        return 'Lock';
+    }
+  }
+
+  private missionControlTimelineReasonLabel(
+    entry: AdminQualityMissionRadarLockHistoryEntry,
+  ): string {
+    if (entry.kind === 'action') {
+      return this.missionControlActionLabel(entry.action ?? 'approve');
+    }
+
+    if (entry.kind === 'proof') {
+      return 'Proof surge';
+    }
+
+    return this.missionControlLockReasonLabel(entry.reason ?? 'section-pulse');
+  }
+
+  private missionControlTimelineSignalTone(
+    entry: AdminQualityMissionRadarLockHistoryEntry,
+  ): AdminQualityMissionRadarSignalTone {
+    if (entry.kind === 'action') {
+      return entry.actionTone ?? 'primary';
+    }
+
+    if (entry.kind === 'proof') {
+      return 'proof';
+    }
+
+    switch (entry.reason) {
+      case 'manual-targeting':
+        return 'manual';
+      case 'proof-surge':
+        return 'proof';
+      default:
+        return 'pulse';
+    }
+  }
+
+  private missionControlRadarSignalStyleVars(
+    signalTone: AdminQualityMissionRadarSignalTone | null,
+  ): Record<string, string> {
+    switch (signalTone) {
+      case 'proof':
+      case 'success':
+        return {
+          '--og7-cockpit-accent': 'rgba(52, 211, 153, 0.24)',
+          '--og7-cockpit-accent-strong': 'rgba(16, 185, 129, 0.44)',
+          '--og7-cockpit-outline': 'rgba(52, 211, 153, 0.22)',
+          '--og7-cockpit-glow': 'rgba(16, 185, 129, 0.34)',
+          '--og7-cockpit-sweep': 'rgba(110, 231, 183, 0.4)',
+          '--og7-cockpit-band': 'rgba(52, 211, 153, 0.26)',
+        };
+      case 'manual':
+      case 'primary':
+        return {
+          '--og7-cockpit-accent': 'rgba(59, 130, 246, 0.24)',
+          '--og7-cockpit-accent-strong': 'rgba(96, 165, 250, 0.44)',
+          '--og7-cockpit-outline': 'rgba(96, 165, 250, 0.22)',
+          '--og7-cockpit-glow': 'rgba(59, 130, 246, 0.3)',
+          '--og7-cockpit-sweep': 'rgba(147, 197, 253, 0.38)',
+          '--og7-cockpit-band': 'rgba(96, 165, 250, 0.26)',
+        };
+      case 'secondary':
+        return {
+          '--og7-cockpit-accent': 'rgba(168, 85, 247, 0.22)',
+          '--og7-cockpit-accent-strong': 'rgba(192, 132, 252, 0.42)',
+          '--og7-cockpit-outline': 'rgba(192, 132, 252, 0.2)',
+          '--og7-cockpit-glow': 'rgba(168, 85, 247, 0.3)',
+          '--og7-cockpit-sweep': 'rgba(216, 180, 254, 0.36)',
+          '--og7-cockpit-band': 'rgba(192, 132, 252, 0.24)',
+        };
+      case 'danger':
+        return {
+          '--og7-cockpit-accent': 'rgba(244, 63, 94, 0.24)',
+          '--og7-cockpit-accent-strong': 'rgba(251, 113, 133, 0.44)',
+          '--og7-cockpit-outline': 'rgba(251, 113, 133, 0.2)',
+          '--og7-cockpit-glow': 'rgba(244, 63, 94, 0.32)',
+          '--og7-cockpit-sweep': 'rgba(253, 164, 175, 0.36)',
+          '--og7-cockpit-band': 'rgba(251, 113, 133, 0.24)',
+        };
+      case 'neutral':
+        return {
+          '--og7-cockpit-accent': 'rgba(148, 163, 184, 0.22)',
+          '--og7-cockpit-accent-strong': 'rgba(203, 213, 225, 0.36)',
+          '--og7-cockpit-outline': 'rgba(148, 163, 184, 0.18)',
+          '--og7-cockpit-glow': 'rgba(148, 163, 184, 0.24)',
+          '--og7-cockpit-sweep': 'rgba(226, 232, 240, 0.32)',
+          '--og7-cockpit-band': 'rgba(148, 163, 184, 0.2)',
+        };
+      case 'pulse':
+        return {
+          '--og7-cockpit-accent': 'rgba(245, 158, 11, 0.22)',
+          '--og7-cockpit-accent-strong': 'rgba(251, 191, 36, 0.42)',
+          '--og7-cockpit-outline': 'rgba(251, 191, 36, 0.2)',
+          '--og7-cockpit-glow': 'rgba(245, 158, 11, 0.28)',
+          '--og7-cockpit-sweep': 'rgba(253, 224, 71, 0.38)',
+          '--og7-cockpit-band': 'rgba(251, 191, 36, 0.24)',
+        };
+      default:
+        return {};
+    }
+  }
+
+  missionControlRadarOpacity(): string {
+    switch (this.missionControlProofStreamIntensity()) {
+      case 'high':
+        return '1';
+      case 'medium':
+        return '0.88';
+      default:
+        return '0.72';
+    }
+  }
+
+  missionControlRadarSweepOpacity(): string {
+    switch (this.missionControlProofStreamIntensity()) {
+      case 'high':
+        return '0.82';
+      case 'medium':
+        return '0.7';
+      default:
+        return '0.56';
+    }
+  }
+
+  missionControlRadarFieldOpacity(): string {
+    switch (this.missionControlProofStreamIntensity()) {
+      case 'high':
+        return '1';
+      case 'medium':
+        return '0.92';
+      default:
+        return '0.82';
+    }
+  }
+
+  missionControlRadarSweepSpeed(): 'slow' | 'nominal' | 'fast' | 'alert' {
+    switch (this.missionHudAmbientTone()) {
+      case 'critical':
+        return 'alert';
+      case 'syncing':
+        return 'fast';
+      case 'warning':
+        return 'slow';
+      default:
+        return 'nominal';
+    }
+  }
+
+  missionControlRadarAcquisitionRingClasses(point: AdminQualityMissionRadarEchoPoint): string {
+    if (!point.active) {
+      return 'border-transparent opacity-0 scale-90';
+    }
+
+    return point.pulsing
+      ? 'border-[var(--og7-cockpit-accent-strong)] opacity-95 scale-100 shadow-[0_0_22px_var(--og7-cockpit-glow)]'
+      : 'border-[var(--og7-cockpit-accent)] opacity-80 scale-100 shadow-[0_0_16px_var(--og7-cockpit-glow)]';
+  }
+
+  private resolveRadarEchoIntensity(
+    count: number,
+    total: number,
+    highCount: number,
+    highRatio: number,
+    mediumCount: number,
+    mediumRatio: number,
+  ): AdminQualityMissionRadarEchoIntensity {
+    const safeTotal = Math.max(total, 1);
+    const ratio = count / safeTotal;
+
+    if (count >= highCount || ratio >= highRatio) {
+      return 'high';
+    }
+
+    if (count >= mediumCount || ratio >= mediumRatio) {
+      return 'medium';
+    }
+
+    return 'low';
+  }
+
+  private resolveMissionRadarSweepDuration(): string {
+    switch (this.missionHudAmbientTone()) {
+      case 'critical':
+        return '7.5s';
+      case 'syncing':
+        return '11s';
+      case 'warning':
+        return '20s';
+      default:
+        return '16s';
+    }
+  }
+
+  missionHudEnergyTrackClasses(state: AdminQualityMissionHudLaneState): string {
+    switch (state) {
+      case 'flowing':
+        return 'bg-gradient-to-r from-cyan-300 via-sky-300 to-emerald-300 shadow-[0_0_22px_rgba(56,189,248,0.35)]';
+      case 'charged':
+        return 'bg-gradient-to-r from-amber-300/90 via-cyan-300/80 to-sky-300/75';
+      case 'fault':
+        return 'bg-gradient-to-r from-rose-300/90 via-rose-400/80 to-amber-300/50';
+      default:
+        return 'bg-white/12';
+    }
+  }
+
+  missionHudEnergyNodeClasses(state: AdminQualityMissionHudLaneState): string {
+    switch (state) {
+      case 'flowing':
+        return 'border-cyan-300/40 bg-cyan-300/25 text-cyan-100 shadow-[0_0_18px_rgba(56,189,248,0.32)]';
+      case 'charged':
+        return 'border-amber-300/40 bg-amber-300/18 text-amber-100';
+      case 'fault':
+        return 'border-rose-300/40 bg-rose-300/18 text-rose-100';
+      default:
+        return 'border-white/12 bg-white/5 text-slate-300';
     }
   }
 
@@ -732,7 +2209,7 @@ export class AdminQualityPage implements OnInit {
   }
 
   async copyCodexPrompt(plan: AdminQualityDelegationPlan): Promise<void> {
-    await this.copyText(plan.codexPrompt, 'Brief Codex copie.');
+    await this.copyText(plan.codexPrompt, 'Brief AI copie.');
   }
 
   async copyIssue(plan: AdminQualityDelegationPlan): Promise<void> {
@@ -953,6 +2430,203 @@ export class AdminQualityPage implements OnInit {
     this.selectedMissionId.set(recommendation.id);
     this.saveMissionDecisionToServer(recommendation, status, message);
     this.notifications.success(message, { source: 'admin-quality' });
+  }
+
+  private loadAiDispatchReadiness(silent: boolean): void {
+    if (silent && this.aiOpsSecurity()) {
+      this.aiOpsSecurityRefreshing.set(true);
+    } else {
+      this.aiOpsSecurityRefreshing.set(false);
+      this.aiOpsSecurityStatus.set('loading');
+      this.aiOpsProofStatus.set('loading');
+    }
+
+    forkJoin({
+      security: this.opsService.getSecurity().pipe(catchError(() => of(null))),
+      proofs: this.opsService.getAiProofs().pipe(catchError(() => of(null))),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ security, proofs }) => {
+          if (security) {
+            this.aiOpsSecurity.set(security);
+            this.aiOpsSecurityStatus.set('ready');
+            this.aiOpsSecurityDegraded.set(false);
+            this.aiOpsLastSuccessfulRefreshAt.set(Date.now());
+          } else if (this.aiOpsSecurity()) {
+            this.aiOpsSecurityDegraded.set(true);
+            this.aiOpsSecurityStatus.set('ready');
+          } else {
+            this.aiOpsSecurity.set(null);
+            this.aiOpsSecurityStatus.set('unavailable');
+          }
+
+          if (proofs) {
+            this.aiOpsProofs.set(proofs);
+            this.aiOpsProofStatus.set('ready');
+          } else if (!this.aiOpsProofs()) {
+            this.aiOpsProofStatus.set('unavailable');
+          }
+
+          this.aiOpsSecurityRefreshing.set(false);
+        },
+        error: () => {
+          this.aiOpsSecurityRefreshing.set(false);
+          this.aiOpsSecurity.set(null);
+          this.aiOpsSecurityStatus.set('unavailable');
+          this.aiOpsProofStatus.set('unavailable');
+        },
+      });
+  }
+
+  private aiOpsRefreshCountdownSeconds(): number {
+    const lastRefreshAt = this.aiOpsLastSuccessfulRefreshAt();
+    if (lastRefreshAt == null) {
+      return 0;
+    }
+
+    const elapsedMs = this.aiOpsLiveNow() - lastRefreshAt;
+    const remainingMs = Math.max(0, ADMIN_QUALITY_AI_OPS_REFRESH_INTERVAL_MS - elapsedMs);
+    return Math.ceil(remainingMs / 1000);
+  }
+
+  private formatAiTelemetryRelative(timestampMs: number): string {
+    const deltaMs = Math.max(0, this.aiOpsLiveNow() - timestampMs);
+    const seconds = Math.floor(deltaMs / 1000);
+    if (seconds < 5) {
+      return 'just now';
+    }
+    if (seconds < 60) {
+      return `${seconds}s ago`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes}m ago`;
+    }
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ago`;
+  }
+
+  private dispatchSelectedMission(
+    recommendation: AdminQualityMissionRecommendation,
+    successMessage: string,
+  ): void {
+    if (!this.selectedAiDispatchReady()) {
+      this.notifications.error(this.selectedAiDispatchBlockedMessage(), {
+        source: 'admin-quality',
+      });
+      return;
+    }
+
+    if (!this.confirmAiDispatch(recommendation)) {
+      return;
+    }
+
+    this.aiDispatchingMissionId.set(recommendation.id);
+
+    this.opsService
+      .dispatchCodexWorkflow({
+        provider: this.selectedAiProvider(),
+        task: recommendation.operatorPrompt,
+        scope: this.resolveCodexScope(recommendation.targetFiles),
+        baseBranch: 'main',
+        draftPr: true,
+        model: this.selectedAiProviderModel(),
+        effort: null,
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          if (this.aiDispatchingMissionId() === recommendation.id) {
+            this.aiDispatchingMissionId.set(null);
+          }
+        }),
+      )
+      .subscribe({
+        next: (result) => {
+          this.updateMissionStatus(recommendation, 'in-progress', successMessage);
+          this.notifications.info(
+            `${this.selectedAiProviderLabel()} queued via ${result.workflow} on ${result.ref}.`,
+            { source: 'admin-quality' },
+          );
+          this.loadAiDispatchReadiness(true);
+        },
+        error: (error: unknown) => {
+          this.notifications.error(this.resolveOpsDispatchError(error), {
+            source: 'admin-quality',
+          });
+        },
+      });
+  }
+
+  private confirmAiDispatch(recommendation: AdminQualityMissionRecommendation): boolean {
+    if (!this.isBrowser || typeof window === 'undefined' || typeof window.confirm !== 'function') {
+      return true;
+    }
+
+    return window.confirm(
+      [
+        `Lancer ${this.selectedAiProviderLabel()} depuis la console de pilotage ?`,
+        '',
+        recommendation.title,
+        `Workflow: ${this.selectedAiDispatchWorkflow()}`,
+      ].join('\n'),
+    );
+  }
+
+  private selectedAiDispatchBlockedMessage(): string {
+    const provider = this.selectedAiProviderLabel();
+    const status = this.selectedAiDispatchStatusLabel();
+
+    if (this.aiOpsSecurityStatus() === 'unavailable') {
+      return `Impossible de verifier l'etat Ops avant de lancer ${provider}. Ouvrez Ops et retentez apres verification.`;
+    }
+
+    return `${provider} n'est pas pret pour le dispatch: ${status}. Verifiez la cle et le flag dans Ops.`;
+  }
+
+  private resolveOpsDispatchError(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const payload = error.error;
+      if (payload && typeof payload === 'object') {
+        const nestedMessage = (payload as { error?: { message?: unknown }; message?: unknown })
+          .error?.message;
+        if (typeof nestedMessage === 'string' && nestedMessage.trim()) {
+          return nestedMessage;
+        }
+        const message = (payload as { message?: unknown }).message;
+        if (typeof message === 'string' && message.trim()) {
+          return message;
+        }
+      }
+      if (typeof payload === 'string' && payload.trim()) {
+        return payload;
+      }
+      if (error.message.trim()) {
+        return error.message;
+      }
+    }
+
+    if (error instanceof Error && error.message.trim()) {
+      return error.message;
+    }
+
+    return `${this.selectedAiProviderLabel()} dispatch failed. Review Ops before retrying.`;
+  }
+
+  private aiProofStateLabel(state: AdminQualityAiProofModule['state']): string {
+    switch (state) {
+      case 'completed':
+        return 'Proof package ready';
+      case 'in-progress':
+        return 'Proof pipeline active';
+      case 'queued':
+        return 'Proof pipeline queued';
+      case 'failed':
+        return 'Proof pipeline failed';
+      default:
+        return 'Proof feed unavailable';
+    }
   }
 
   private loadMissionDecisionsFromServer(): void {
@@ -1235,11 +2909,11 @@ export class AdminQualityPage implements OnInit {
       if (parsed.selectedMissionId === null || typeof parsed.selectedMissionId === 'string') {
         this.selectedMissionId.set(parsed.selectedMissionId);
       }
-      if (
-        typeof parsed.availableCodexQuotaUnits === 'number' &&
-        Number.isFinite(parsed.availableCodexQuotaUnits)
-      ) {
-        this.availableCodexQuotaUnits.set(Math.max(0, Math.round(parsed.availableCodexQuotaUnits)));
+      if (isAdminAiProvider(parsed.selectedAiProvider)) {
+        this.selectedAiProvider.set(parsed.selectedAiProvider);
+      }
+      if (typeof parsed.missionHudExpanded === 'boolean') {
+        this.missionHudExpanded.set(parsed.missionHudExpanded);
       }
       if (this.isWorkspaceSurface(parsed.activeWorkspaceSurface)) {
         this.activeWorkspaceSurface.set(parsed.activeWorkspaceSurface);
@@ -1266,7 +2940,8 @@ export class AdminQualityPage implements OnInit {
       selectedActionId: this.selectedActionId(),
       selectedMissionId: this.selectedMissionId(),
       activeWorkspaceSurface: this.activeWorkspaceSurface(),
-      availableCodexQuotaUnits: this.availableCodexQuotaUnits(),
+      selectedAiProvider: this.selectedAiProvider(),
+      missionHudExpanded: this.missionHudExpanded(),
     };
 
     try {
@@ -1308,28 +2983,246 @@ export class AdminQualityPage implements OnInit {
     return value === 'delegation' || value === 'actions';
   }
 
-  private quotaSummaryForMission(
-    recommendation: AdminQualityMissionRecommendation,
-  ): AdminQualityMissionQuotaSummary {
-    const difficulty = this.selectedDelegation()?.difficulty ?? 'Medium';
-    const tasks = buildMissionTasks(recommendation, difficulty);
-    return summarizeMissionQuota(tasks, this.availableCodexQuotaUnits());
+  private registerMissionHudScrollSpy(): void {
+    if (!this.isBrowser || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const sections = this.missionHudSectionOrder
+      .map((section) => [section, this.resolveMissionHudSectionElement(section)?.nativeElement] as const)
+      .filter((entry): entry is readonly [AdminQualityMissionHudSection, HTMLElement] =>
+        Boolean(entry[1]),
+      );
+
+    if (!sections.length) {
+      return;
+    }
+
+    const ratios = new Map<AdminQualityMissionHudSection, number>();
+    this.missionHudSectionObserver?.disconnect();
+    this.missionHudSectionObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const section = sections.find(([, element]) => element === entry.target)?.[0];
+          if (!section) {
+            continue;
+          }
+          ratios.set(section, entry.isIntersecting ? entry.intersectionRatio : 0);
+        }
+
+        const nextSection = this.missionHudSectionOrder.reduce<AdminQualityMissionHudSection>(
+          (best, section) => {
+            const score = ratios.get(section) ?? 0;
+            const bestScore = ratios.get(best) ?? 0;
+            return score > bestScore ? section : best;
+          },
+          this.missionHudActiveSection(),
+        );
+
+        this.setMissionHudSection(nextSection, 'section-pulse');
+      },
+      {
+        root: null,
+        threshold: [0.2, 0.45, 0.7],
+        rootMargin: '-18% 0px -50% 0px',
+      },
+    );
+
+    for (const [, element] of sections) {
+      this.missionHudSectionObserver.observe(element);
+    }
   }
 
-  private openCodexOpsPrefill(recommendation: AdminQualityMissionRecommendation): Promise<boolean> {
-    return this.router.navigate(['/admin/ops'], {
-      queryParams: {
-        codexTask: recommendation.operatorPrompt,
-        codexScope: this.resolveCodexScope(recommendation.targetFiles),
-        codexBaseBranch: 'main',
-        codexDraftPr: 'true',
-        codexSource: 'admin-quality',
-        codexMissionId: recommendation.id,
-      },
+  private resolveMissionHudSectionElement(
+    section: AdminQualityMissionHudSection,
+  ): ElementRef<HTMLElement> | undefined {
+    switch (section) {
+      case 'mission':
+        return this.missionSection;
+      case 'workspace':
+        return this.workspaceSection;
+      default:
+        return this.coverageSection;
+    }
+  }
+
+  private resolveMissionHudLaneState(
+    missionStatus: AdminQualityMissionStatus,
+    dispatchReady: boolean,
+    proofStage: boolean,
+  ): AdminQualityMissionHudLaneState {
+    if (missionStatus === 'blocked' || missionStatus === 'rejected') {
+      return 'fault';
+    }
+
+    if (proofStage) {
+      if (missionStatus === 'proof-returned' || missionStatus === 'done') {
+        return 'flowing';
+      }
+
+      if (missionStatus === 'in-progress') {
+        return 'charged';
+      }
+
+      return 'standby';
+    }
+
+    if (missionStatus === 'in-progress' || missionStatus === 'proof-returned' || missionStatus === 'done') {
+      return 'flowing';
+    }
+
+    if (missionStatus === 'approved' && dispatchReady) {
+      return 'charged';
+    }
+
+    return dispatchReady ? 'flowing' : 'standby';
+  }
+
+  private triggerMissionHudSectionPulse(section: AdminQualityMissionHudSection): void {
+    this.missionHudPulsingSection.set(section);
+    if (this.missionHudSectionPulseTimer) {
+      clearTimeout(this.missionHudSectionPulseTimer);
+    }
+    this.missionHudSectionPulseTimer = setTimeout(() => {
+      this.missionHudPulsingSection.set(null);
+      this.missionHudSectionPulseTimer = null;
+    }, 950);
+  }
+
+  private triggerMissionHudProofPulse(): void {
+    this.missionHudProofPulseActive.set(true);
+    if (this.missionHudProofPulseTimer) {
+      clearTimeout(this.missionHudProofPulseTimer);
+    }
+    this.missionHudProofPulseTimer = setTimeout(() => {
+      this.missionHudProofPulseActive.set(false);
+      this.missionHudProofPulseTimer = null;
+    }, 1400);
+  }
+
+  private recordMissionControlLock(
+    section: AdminQualityMissionHudSection,
+    stateLabel: 'Locked' | 'Acquiring',
+    reason: AdminQualityMissionRadarLockReason,
+  ): void {
+    this.focusMissionControlPanel(section);
+    const entry: AdminQualityMissionRadarLockHistoryEntry = {
+      sequence: ++this.missionControlRadarLockSequence,
+      id: section,
+      kind: 'lock',
+      stateLabel,
+      reason,
+      detailLabel: `${stateLabel} ${this.missionControlSectionLabel(section)}`,
+    };
+    this.missionControlRadarLockHistory.update((history) => [
+      entry,
+      ...history,
+    ].slice(0, 5));
+  }
+
+  private missionControlLockReasonLabel(reason: AdminQualityMissionRadarLockReason): string {
+    switch (reason) {
+      case 'proof-surge':
+        return 'Proof surge';
+      case 'manual-targeting':
+        return 'Manual targeting';
+      default:
+        return 'Section pulse';
+    }
+  }
+
+  private missionControlActionLabel(action: AdminQualityMissionControlAction): string {
+    switch (action) {
+      case 'approve':
+        return 'Approve';
+      case 'auto-delegate':
+        return 'Delegate';
+      case 'defer':
+        return 'Defer';
+      case 'block':
+        return 'Block';
+      case 'reset':
+        return 'Reset';
+      case 'return-proof':
+        return 'Return proof';
+      case 'complete':
+        return 'Complete';
+      default:
+        return 'Action';
+    }
+  }
+
+  private missionControlActionTone(action: AdminQualityMissionControlAction): AdminQualityMissionActionTone {
+    switch (action) {
+      case 'auto-delegate':
+        return 'secondary';
+      case 'block':
+        return 'danger';
+      case 'defer':
+      case 'reset':
+        return 'neutral';
+      case 'return-proof':
+        return 'success';
+      default:
+        return 'primary';
+    }
+  }
+
+  private missionControlSectionLabel(section: AdminQualityMissionHudSection): string {
+    return this.missionHudSectionOptions.find((option) => option.id === section)?.label ?? 'Coverage matrix';
+  }
+
+  private recordMissionControlAction(event: AdminQualityMissionControlActionEvent): void {
+    this.focusMissionControlPanel('mission');
+    const entry: AdminQualityMissionRadarLockHistoryEntry = {
+      sequence: ++this.missionControlRadarLockSequence,
+      id: 'mission',
+      kind: 'action',
+      stateLabel: this.missionControlActionLabel(event.action),
+      action: event.action,
+      actionTone: this.missionControlActionTone(event.action),
+      detailLabel: `${this.missionControlActionLabel(event.action)} · ${event.recommendation.title}`,
+    };
+    this.missionControlRadarLockHistory.update((history) => [
+      entry,
+      ...history,
+    ].slice(0, 5));
+  }
+
+  private recordMissionControlProofEvent(
+    section: AdminQualityMissionHudSection,
+    proofLabel: string,
+  ): void {
+    this.focusMissionControlPanel(section);
+    const entry: AdminQualityMissionRadarLockHistoryEntry = {
+      sequence: ++this.missionControlRadarLockSequence,
+      id: section,
+      kind: 'proof',
+      stateLabel: 'Proof pulse',
+      detailLabel: `${proofLabel} · ${this.missionControlSectionLabel(section)}`,
+    };
+    this.missionControlRadarLockHistory.update((history) => [
+      entry,
+      ...history,
+    ].slice(0, 5));
+  }
+
+  private focusMissionControlPanel(section: AdminQualityMissionHudSection): void {
+    this.missionControlFocusedPanel.set(section);
+    if (this.missionControlPanelFocusTimer) {
+      clearTimeout(this.missionControlPanelFocusTimer);
+    }
+    this.ngZone.runOutsideAngular(() => {
+      this.missionControlPanelFocusTimer = setTimeout(() => {
+        this.ngZone.run(() => {
+          this.missionControlFocusedPanel.set(null);
+          this.missionControlPanelFocusTimer = null;
+        });
+      }, 1800);
     });
   }
 
-  private resolveCodexScope(targetFiles: readonly string[]): string {
+  private resolveCodexScope(targetFiles: readonly string[]): AdminOpsCodexScope {
     if (targetFiles.length && targetFiles.every((file) => file.startsWith('strapi/'))) {
       return 'strapi';
     }

--- a/openg7-org/src/assets/i18n/en.json
+++ b/openg7-org/src/assets/i18n/en.json
@@ -651,7 +651,7 @@
           }
         },
         "notifications": {
-          "briefCopied": "Codex brief copied.",
+          "briefCopied": "AI brief copied.",
           "issueCopied": "GitHub issue copied.",
           "copyFailed": "Unable to copy the workspace item.",
           "githubUnavailable": "No GitHub URL is available for this delegation."
@@ -1712,12 +1712,7 @@
             "province": "QC",
             "status": "Founder",
             "location": "Thetford Mines, Quebec",
-            "skills": [
-              "Angular",
-              "TypeScript",
-              "Product strategy",
-              "Ecosystem design"
-            ],
+            "skills": ["Angular", "TypeScript", "Product strategy", "Ecosystem design"],
             "impact": "Laying the digital, strategic and human foundations of OpenG7 as a founder-led public-interest initiative.",
             "contribution": "Shapes the product direction, full-stack delivery and the initial operating model for the platform.",
             "focus": "Building the first release, structuring partnerships and turning a founder's note into an operational ecosystem.",
@@ -1773,31 +1768,19 @@
             "id": "nationalCoordination",
             "title": "National coordination",
             "summary": "Harmonise interprovincial flows and shared references.",
-            "tags": [
-              "Open data",
-              "Interoperability",
-              "Security"
-            ]
+            "tags": ["Open data", "Interoperability", "Security"]
           },
           {
             "id": "digitalInnovation",
             "title": "Digital innovation",
             "summary": "Interactive maps, open AI and real-time integrations.",
-            "tags": [
-              "Angular",
-              "NgRx",
-              "Leaflet"
-            ]
+            "tags": ["Angular", "NgRx", "Leaflet"]
           },
           {
             "id": "communityPartnerships",
             "title": "Community partnerships",
             "summary": "Connect SMEs, clusters and local institutions.",
-            "tags": [
-              "Clusters",
-              "SMEs",
-              "Academic"
-            ]
+            "tags": ["Clusters", "SMEs", "Academic"]
           }
         ]
       }
@@ -1927,26 +1910,17 @@
           {
             "title": "Co-design",
             "description": "Mixed working groups iterate scenarios, privacy guardrails and funding needs.",
-            "deliverables": [
-              "Open workshop notes",
-              "Risk register updated"
-            ]
+            "deliverables": ["Open workshop notes", "Risk register updated"]
           },
           {
             "title": "Decide",
             "description": "The stewardship board votes in public session with rationale recorded and streamed.",
-            "deliverables": [
-              "Voting record",
-              "Implementation charter"
-            ]
+            "deliverables": ["Voting record", "Implementation charter"]
           },
           {
             "title": "Review",
             "description": "Results are measured against agreed indicators and lessons learned feed back into planning.",
-            "deliverables": [
-              "Post-implementation review",
-              "Updated public roadmap"
-            ]
+            "deliverables": ["Post-implementation review", "Updated public roadmap"]
           }
         ]
       },
@@ -3199,8 +3173,14 @@
               }
             },
             "fields": {
-              "title": { "label": "Offer title", "placeholder": "Example: Spare chilled storage capacity available near Montreal hub" },
-              "summary": { "label": "Summary", "placeholder": "Describe the spare capacity, target products, and service level expectations." },
+              "title": {
+                "label": "Offer title",
+                "placeholder": "Example: Spare chilled storage capacity available near Montreal hub"
+              },
+              "summary": {
+                "label": "Summary",
+                "placeholder": "Describe the spare capacity, target products, and service level expectations."
+              },
               "availablePallets": { "label": "Available pallet positions" },
               "temperatureRange": {
                 "label": "Temperature range",
@@ -3223,9 +3203,15 @@
               "availableUntil": { "label": "Available until" },
               "fromProvinceId": { "label": "Origin province" },
               "toProvinceId": { "label": "Target province" },
-              "contactChannel": { "label": "Operations contact", "placeholder": "Example: Cold-chain coordination desk" },
+              "contactChannel": {
+                "label": "Operations contact",
+                "placeholder": "Example: Cold-chain coordination desk"
+              },
               "minimumCommitmentDays": { "label": "Minimum commitment (days)" },
-              "handlingNotes": { "label": "Handling notes", "help": "Add packaging, loading, or temperature-control instructions relevant to the offer." },
+              "handlingNotes": {
+                "label": "Handling notes",
+                "help": "Add packaging, loading, or temperature-control instructions relevant to the offer."
+              },
               "tags": { "label": "Tags", "placeholder": "Example: frozen, overflow, certified" }
             },
             "validation": {
@@ -3234,7 +3220,9 @@
                 "maxLength": "Keep the title under 160 characters."
               },
               "summary": { "minLength": "Provide at least ten characters in the summary." },
-              "availablePallets": { "min": "Available pallet positions must be greater than zero." },
+              "availablePallets": {
+                "min": "Available pallet positions must be greater than zero."
+              },
               "availableUntil": { "dateOrder": "The end date must be on or after the start date." },
               "minimumCommitmentDays": { "min": "Minimum commitment must be at least one day." }
             }
@@ -3526,9 +3514,7 @@
         },
         "credits": {
           "title": "Credits & partners",
-          "paragraphs": [
-            "OpenG7 acknowledges the contributions of the following partners:"
-          ],
+          "paragraphs": ["OpenG7 acknowledges the contributions of the following partners:"],
           "bullets": [
             "Innovation, Science and Economic Development Canada for strategic guidance.",
             "Global Affairs Canada for international market intelligence.",
@@ -4799,27 +4785,27 @@
       },
       "codex": {
         "runway": {
-          "label": "Codex runway",
-          "title": "Generated task runway",
-          "subtitle": "Estimate the task volume before starting the selected mission.",
+          "label": "{{ provider }} Ops clearance",
+          "title": "Generated task plan for {{ provider }}",
+          "subtitle": "Review the estimated task volume and live Ops readiness before dispatch.",
           "status": {
-            "sufficient": "Quota sufficient",
-            "insufficient": "Quota insufficient"
+            "sufficient": "Ops ready",
+            "insufficient": "Ops blocked"
           },
           "metrics": {
             "tasks": "Tasks",
             "tasksBody": "Generated from the active mission.",
-            "required": "Required quota",
+            "required": "Estimated units",
             "requiredBody": "Estimated units for the current plan.",
-            "available": "Available quota",
-            "availableBody": "Local operator estimate until Codex usage is connected.",
-            "remaining": "Runway left",
-            "remainingBody": "Units left after this mission.",
-            "missing": "Units missing",
-            "missingBody": "Increase the quota before launching the task."
+            "available": "Ops status",
+            "availableBody": "Live readiness from the Owner Ops security endpoint for {{ provider }}.",
+            "remaining": "Workflow",
+            "remainingBody": "GitHub Actions workflow selected by the backend.",
+            "missing": "Workflow",
+            "missingBody": "Fix the Ops readiness blocker before dispatch."
           },
-          "ready": "The mission can be delegated without exceeding the current quota estimate.",
-          "blocked": "Increase the available quota before launching the generated task set."
+          "ready": "{{ provider }} can be dispatched directly from Mission Control.",
+          "blocked": "{{ provider }} dispatch is blocked until Ops reports an enabled workflow and inserted key."
         },
         "tasks": {
           "label": "Generated tasks",
@@ -4834,10 +4820,9 @@
           }
         },
         "notifications": {
-          "insufficientQuota": "Quota too low: {{ required }} unit(s) required, {{ available }} available, {{ missing }} missing."
+          "insufficientQuota": "{{ provider }} Ops readiness is blocking dispatch."
         }
       }
     }
   }
 }
-

--- a/openg7-org/src/assets/i18n/fr.json
+++ b/openg7-org/src/assets/i18n/fr.json
@@ -625,7 +625,7 @@
             "execution": "Plan d execution probable",
             "files": "Fichiers",
             "validation": "Validation",
-            "brief": "Brief Codex",
+            "brief": "Brief AI",
             "briefBody": "Prompt pret a copier, relire ou deleguer rapidement.",
             "issue": "Issue GitHub",
             "issueBody": "Issue precomposee pour delegation ou suivi."
@@ -651,7 +651,7 @@
           }
         },
         "notifications": {
-          "briefCopied": "Brief Codex copie.",
+          "briefCopied": "Brief AI copie.",
           "issueCopied": "Issue GitHub copiee.",
           "copyFailed": "Impossible de copier l element du workspace.",
           "githubUnavailable": "Aucune URL GitHub n est disponible pour cette delegation."
@@ -1601,12 +1601,7 @@
             "province": "QC",
             "status": "Fondatrice",
             "location": "Thetford Mines, Québec",
-            "skills": [
-              "Angular",
-              "TypeScript",
-              "Stratégie produit",
-              "Design d’écosystème"
-            ],
+            "skills": ["Angular", "TypeScript", "Stratégie produit", "Design d’écosystème"],
             "impact": "Pose les bases numériques, stratégiques et humaines d’OpenG7 comme initiative d’intérêt public portée par sa fondatrice.",
             "contribution": "Définit la direction produit, la livraison full-stack et le premier modèle opératoire de la plateforme.",
             "focus": "Construire la première version, structurer les partenariats et transformer un mot de la fondatrice en écosystème opérationnel.",
@@ -1662,31 +1657,19 @@
             "id": "nationalCoordination",
             "title": "Coordination nationale",
             "summary": "Harmoniser les flux interprovinciaux et les référentiels.",
-            "tags": [
-              "Données ouvertes",
-              "Interopérabilité",
-              "Sécurité"
-            ]
+            "tags": ["Données ouvertes", "Interopérabilité", "Sécurité"]
           },
           {
             "id": "digitalInnovation",
             "title": "Innovation numérique",
             "summary": "Cartes interactives, IA ouverte et intégration temps réel.",
-            "tags": [
-              "Angular",
-              "NgRx",
-              "Leaflet"
-            ]
+            "tags": ["Angular", "NgRx", "Leaflet"]
           },
           {
             "id": "communityPartnerships",
             "title": "Partenariats communautaires",
             "summary": "Relier PME, clusters et institutions locales.",
-            "tags": [
-              "Clusters",
-              "PME",
-              "Académique"
-            ]
+            "tags": ["Clusters", "PME", "Académique"]
           }
         ]
       }
@@ -1816,26 +1799,17 @@
           {
             "title": "Co-concevoir",
             "description": "Des groupes mixtes explorent scénarios, garde-fous de confidentialité et besoins de financement.",
-            "deliverables": [
-              "Comptes rendus ouverts",
-              "Registre des risques mis à jour"
-            ]
+            "deliverables": ["Comptes rendus ouverts", "Registre des risques mis à jour"]
           },
           {
             "title": "Décider",
             "description": "Le conseil vote en séance publique avec motivations consignées et diffusion en direct.",
-            "deliverables": [
-              "Registre des votes",
-              "Charte de mise en œuvre"
-            ]
+            "deliverables": ["Registre des votes", "Charte de mise en œuvre"]
           },
           {
             "title": "Évaluer",
             "description": "Les résultats sont mesurés selon les indicateurs convenus et les apprentissages alimentent la planification.",
-            "deliverables": [
-              "Revue post-implantation",
-              "Feuille de route publique mise à jour"
-            ]
+            "deliverables": ["Revue post-implantation", "Feuille de route publique mise à jour"]
           }
         ]
       },
@@ -3088,8 +3062,14 @@
               }
             },
             "fields": {
-              "title": { "label": "Titre de l'offre", "placeholder": "Exemple : Capacite de stockage refrigere disponible pres du hub de Montreal" },
-              "summary": { "label": "Resume", "placeholder": "Decrivez la capacite disponible, les produits cibles et le niveau de service attendu." },
+              "title": {
+                "label": "Titre de l'offre",
+                "placeholder": "Exemple : Capacite de stockage refrigere disponible pres du hub de Montreal"
+              },
+              "summary": {
+                "label": "Resume",
+                "placeholder": "Decrivez la capacite disponible, les produits cibles et le niveau de service attendu."
+              },
               "availablePallets": { "label": "Positions palettes disponibles" },
               "temperatureRange": {
                 "label": "Plage thermique",
@@ -3112,10 +3092,19 @@
               "availableUntil": { "label": "Disponible jusqu'au" },
               "fromProvinceId": { "label": "Province d'origine" },
               "toProvinceId": { "label": "Province cible" },
-              "contactChannel": { "label": "Contact operations", "placeholder": "Exemple : cellule de coordination chaine du froid" },
+              "contactChannel": {
+                "label": "Contact operations",
+                "placeholder": "Exemple : cellule de coordination chaine du froid"
+              },
               "minimumCommitmentDays": { "label": "Engagement minimal (jours)" },
-              "handlingNotes": { "label": "Notes de manutention", "help": "Ajoutez les consignes d'emballage, de chargement ou de controle thermique utiles a l'offre." },
-              "tags": { "label": "Etiquettes", "placeholder": "Exemple : congele, debordement, certifie" }
+              "handlingNotes": {
+                "label": "Notes de manutention",
+                "help": "Ajoutez les consignes d'emballage, de chargement ou de controle thermique utiles a l'offre."
+              },
+              "tags": {
+                "label": "Etiquettes",
+                "placeholder": "Exemple : congele, debordement, certifie"
+              }
             },
             "validation": {
               "title": {
@@ -3123,9 +3112,15 @@
                 "maxLength": "Limitez le titre a 160 caracteres."
               },
               "summary": { "minLength": "Fournissez au moins dix caracteres dans le resume." },
-              "availablePallets": { "min": "Le nombre de positions palettes doit etre superieur a zero." },
-              "availableUntil": { "dateOrder": "La date de fin doit etre posterieure ou egale a la date de debut." },
-              "minimumCommitmentDays": { "min": "L'engagement minimal doit etre d'au moins un jour." }
+              "availablePallets": {
+                "min": "Le nombre de positions palettes doit etre superieur a zero."
+              },
+              "availableUntil": {
+                "dateOrder": "La date de fin doit etre posterieure ou egale a la date de debut."
+              },
+              "minimumCommitmentDays": {
+                "min": "L'engagement minimal doit etre d'au moins un jour."
+              }
             }
           }
         }
@@ -3565,9 +3560,7 @@
         },
         "credits": {
           "title": "Partenaires et contributions",
-          "paragraphs": [
-            "OpenG7 remercie les organisations qui soutiennent la plateforme :"
-          ],
+          "paragraphs": ["OpenG7 remercie les organisations qui soutiennent la plateforme :"],
           "bullets": [
             "Innovation, Sciences et Développement économique Canada pour son accompagnement stratégique.",
             "Affaires mondiales Canada pour l’intelligence de marché internationale.",
@@ -4726,27 +4719,27 @@
       },
       "codex": {
         "runway": {
-          "label": "Rampe Codex",
-          "title": "Rampe de taches generees",
-          "subtitle": "Estimer le volume de taches avant de lancer la mission selectionnee.",
+          "label": "Autorisation Ops {{ provider }}",
+          "title": "Plan de taches genere pour {{ provider }}",
+          "subtitle": "Relire le volume estime et l'etat Ops reel avant le dispatch.",
           "status": {
-            "sufficient": "Quota suffisant",
-            "insufficient": "Quota insuffisant"
+            "sufficient": "Ops pret",
+            "insufficient": "Ops bloque"
           },
           "metrics": {
             "tasks": "Taches",
             "tasksBody": "Generees depuis la mission active.",
-            "required": "Quota requis",
+            "required": "Unites estimees",
             "requiredBody": "Unites estimees pour le plan courant.",
-            "available": "Quota disponible",
-            "availableBody": "Estimation operateur locale tant que l usage Codex n est pas branche.",
-            "remaining": "Marge restante",
-            "remainingBody": "Unites restantes apres cette mission.",
-            "missing": "Unites manquantes",
-            "missingBody": "Augmenter le quota avant de lancer la tache."
+            "available": "Etat Ops",
+            "availableBody": "Etat temps reel de {{ provider }} depuis le endpoint security Owner Ops.",
+            "remaining": "Workflow",
+            "remainingBody": "Workflow GitHub Actions selectionne par le backend.",
+            "missing": "Workflow",
+            "missingBody": "Lever le blocage Ops avant le dispatch."
           },
-          "ready": "La mission peut etre deleguee sans depasser l estimation de quota courante.",
-          "blocked": "Augmenter le quota disponible avant de lancer cet ensemble de taches."
+          "ready": "{{ provider }} peut etre lance directement depuis Mission Control.",
+          "blocked": "Le dispatch {{ provider }} reste bloque tant qu Ops ne confirme pas un workflow active et une cle inseree."
         },
         "tasks": {
           "label": "Taches generees",
@@ -4761,10 +4754,9 @@
           }
         },
         "notifications": {
-          "insufficientQuota": "Quota trop faible : {{ required }} unite(s) requises, {{ available }} disponibles, {{ missing }} manquantes."
+          "insufficientQuota": "L'etat Ops de {{ provider }} bloque le dispatch."
         }
       }
     }
   }
 }
-

--- a/packages/contracts/spec/openapi.json
+++ b/packages/contracts/spec/openapi.json
@@ -140,9 +140,65 @@
         }
       }
     },
+    "/api/admin/ops/ai/proofs": {
+      "get": {
+        "summary": "Get the latest GitHub proof telemetry for each AI provider workflow",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminOpsAiProofResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/api/admin/ops/ai/dispatch": {
+      "post": {
+        "summary": "Dispatch a provider-specific GitHub workflow from the owner/admin control plane",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminOpsCodexDispatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminOpsCodexDispatchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "503": {
+            "description": "Dispatch disabled"
+          }
+        }
+      }
+    },
     "/api/admin/ops/codex/dispatch": {
       "post": {
-        "summary": "Dispatch the Codex GitHub workflow from the owner/admin control plane",
+        "summary": "Compatibility alias for the AI dispatch endpoint",
         "requestBody": {
           "required": true,
           "content": {
@@ -874,6 +930,28 @@
                   "sessionIdleTimeoutMs": { "type": "integer", "nullable": true }
                 }
               },
+              "aiKeys": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "enum": ["codex", "copilot", "claude", "gemini"]
+                    },
+                    "label": { "type": "string" },
+                    "workflow": { "type": "string" },
+                    "secretName": { "type": "string", "nullable": true },
+                    "dispatchEnabled": { "type": "boolean" },
+                    "keyInserted": { "type": "boolean" },
+                    "state": {
+                      "type": "string",
+                      "enum": ["ready", "offline", "scan-unavailable", "unsupported"]
+                    },
+                    "note": { "type": "string" }
+                  }
+                }
+              },
               "moderation": {
                 "type": "object",
                 "properties": {
@@ -885,10 +963,83 @@
           }
         }
       },
+      "AdminOpsAiProofResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "generatedAt": { "type": "string", "format": "date-time" },
+              "providers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "enum": ["codex", "copilot", "claude", "gemini"]
+                    },
+                    "label": { "type": "string" },
+                    "workflow": { "type": "string" },
+                    "state": {
+                      "type": "string",
+                      "enum": ["queued", "in-progress", "completed", "failed", "unavailable"]
+                    },
+                    "summary": { "type": "string" },
+                    "run": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "id": { "type": "integer", "nullable": true },
+                        "number": { "type": "integer", "nullable": true },
+                        "url": { "type": "string", "nullable": true },
+                        "status": { "type": "string", "nullable": true },
+                        "conclusion": { "type": "string", "nullable": true },
+                        "branch": { "type": "string", "nullable": true },
+                        "createdAt": { "type": "string", "nullable": true, "format": "date-time" },
+                        "updatedAt": { "type": "string", "nullable": true, "format": "date-time" }
+                      }
+                    },
+                    "artifacts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "nullable": true },
+                          "name": { "type": "string" },
+                          "sizeBytes": { "type": "integer" },
+                          "expired": { "type": "boolean" },
+                          "url": { "type": "string", "nullable": true }
+                        }
+                      }
+                    },
+                    "pullRequest": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "number": { "type": "integer", "nullable": true },
+                        "title": { "type": "string" },
+                        "url": { "type": "string", "nullable": true },
+                        "state": { "type": "string" },
+                        "merged": { "type": "boolean" },
+                        "branch": { "type": "string", "nullable": true }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "AdminOpsCodexDispatchRequest": {
         "type": "object",
         "required": ["task", "scope", "baseBranch", "draftPr"],
         "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["codex", "copilot", "claude", "gemini"]
+          },
           "task": { "type": "string" },
           "scope": {
             "type": "string",
@@ -914,6 +1065,10 @@
             "properties": {
               "queued": { "type": "boolean" },
               "provider": { "type": "string", "enum": ["github-actions"] },
+              "selectedProvider": {
+                "type": "string",
+                "enum": ["codex", "copilot", "claude", "gemini"]
+              },
               "owner": { "type": "string" },
               "repo": { "type": "string" },
               "workflow": { "type": "string" },
@@ -922,6 +1077,10 @@
               "request": {
                 "type": "object",
                 "properties": {
+                  "selectedProvider": {
+                    "type": "string",
+                    "enum": ["codex", "copilot", "claude", "gemini"]
+                  },
                   "scope": {
                     "type": "string",
                     "enum": [

--- a/packages/contracts/src/strapi.rest.d.ts
+++ b/packages/contracts/src/strapi.rest.d.ts
@@ -346,7 +346,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/admin/ops/codex/dispatch": {
+    "/api/admin/ops/ai/proofs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the latest GitHub proof telemetry for each AI provider workflow */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminOpsAiProofResponse"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/ops/ai/dispatch": {
         parameters: {
             query?: never;
             header?: never;
@@ -355,7 +398,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Dispatch the Codex GitHub workflow from the owner/admin control plane */
+        /** Dispatch a provider-specific GitHub workflow from the owner/admin control plane */
         post: {
             parameters: {
                 query?: never;
@@ -436,6 +479,62 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["StatisticsResponse"];
+                    };
+                };
+            };
+        };
+        "/api/admin/ops/codex/dispatch": {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            get?: never;
+            put?: never;
+            /** Compatibility alias for the AI dispatch endpoint */
+            post: {
+                parameters: {
+                    query?: never;
+                    header?: never;
+                    path?: never;
+                    cookie?: never;
+                };
+                requestBody: {
+                    content: {
+                        "application/json": components["schemas"]["AdminOpsCodexDispatchRequest"];
+                    };
+                };
+                responses: {
+                    /** @description OK */
+                    200: {
+                        headers: {
+                            [name: string]: unknown;
+                        };
+                        content: {
+                            "application/json": components["schemas"]["AdminOpsCodexDispatchResponse"];
+                        };
+                    };
+                    /** @description Invalid payload */
+                    400: {
+                        headers: {
+                            [name: string]: unknown;
+                        };
+                        content?: never;
+                    };
+                    /** @description Forbidden */
+                    403: {
+                        headers: {
+                            [name: string]: unknown;
+                        };
+                        content?: never;
+                    };
+                    /** @description Dispatch disabled */
+                    503: {
+                        headers: {
+                            [name: string]: unknown;
+                        };
+                        content?: never;
                     };
                 };
             };
@@ -1117,13 +1216,69 @@ export interface components {
                 auth?: {
                     sessionIdleTimeoutMs?: number | null;
                 };
+                aiKeys?: {
+                    /** @enum {string} */
+                    provider?: "codex" | "copilot" | "claude" | "gemini";
+                    label?: string;
+                    workflow?: string;
+                    secretName?: string | null;
+                    dispatchEnabled?: boolean;
+                    keyInserted?: boolean;
+                    /** @enum {string} */
+                    state?: "ready" | "offline" | "scan-unavailable" | "unsupported";
+                    note?: string;
+                }[];
                 moderation?: {
                     pendingCompanies?: number;
                     suspendedCompanies?: number;
                 };
             };
         };
+        AdminOpsAiProofResponse: {
+            data?: {
+                /** Format: date-time */
+                generatedAt?: string;
+                providers?: {
+                    /** @enum {string} */
+                    provider?: "codex" | "copilot" | "claude" | "gemini";
+                    label?: string;
+                    workflow?: string;
+                    /** @enum {string} */
+                    state?: "queued" | "in-progress" | "completed" | "failed" | "unavailable";
+                    summary?: string;
+                    run?: {
+                        id?: number | null;
+                        number?: number | null;
+                        url?: string | null;
+                        status?: string | null;
+                        conclusion?: string | null;
+                        branch?: string | null;
+                        /** Format: date-time */
+                        createdAt?: string | null;
+                        /** Format: date-time */
+                        updatedAt?: string | null;
+                    } | null;
+                    artifacts?: {
+                        id?: number | null;
+                        name?: string;
+                        sizeBytes?: number;
+                        expired?: boolean;
+                        url?: string | null;
+                    }[];
+                    pullRequest?: {
+                        number?: number | null;
+                        title?: string;
+                        url?: string | null;
+                        state?: string;
+                        merged?: boolean;
+                        branch?: string | null;
+                    } | null;
+                }[];
+            };
+        };
         AdminOpsCodexDispatchRequest: {
+            /** @enum {string} */
+            provider?: "codex" | "copilot" | "claude" | "gemini";
             task: string;
             /** @enum {string} */
             scope: "openg7-org" | "strapi" | "packages-contracts" | "packages-tooling" | "repository-root";
@@ -1137,6 +1292,8 @@ export interface components {
                 queued?: boolean;
                 /** @enum {string} */
                 provider?: "github-actions";
+                /** @enum {string} */
+                selectedProvider?: "codex" | "copilot" | "claude" | "gemini";
                 owner?: string;
                 repo?: string;
                 workflow?: string;
@@ -1144,6 +1301,8 @@ export interface components {
                 /** Format: date-time */
                 requestedAt?: string;
                 request?: {
+                    /** @enum {string} */
+                    selectedProvider?: "codex" | "copilot" | "claude" | "gemini";
                     /** @enum {string} */
                     scope?: "openg7-org" | "strapi" | "packages-contracts" | "packages-tooling" | "repository-root";
                     baseBranch?: string;

--- a/strapi/.env.example
+++ b/strapi/.env.example
@@ -84,6 +84,26 @@ OPS_CODEX_ALLOWED_SCOPES=openg7-org,strapi,packages-contracts,packages-tooling,r
 OPS_CODEX_ALLOWED_BASE_BRANCHES=main
 OPS_CODEX_TIMEOUT_MS=10000
 
+# Déclenchement multi-provider via /api/admin/ops/ai/dispatch
+# Les providers non-Codex reutilisent OPS_AI_GITHUB_* puis, a defaut, OPS_CODEX_GITHUB_*.
+# Copilot reste volontairement desactive tant qu'un runner GitHub stable n'est pas branche dans copilot-pr.yml.
+OPS_AI_GITHUB_TOKEN=
+OPS_AI_GITHUB_OWNER=OpenG7
+OPS_AI_GITHUB_REPO=openg7-platform
+OPS_AI_GITHUB_API_URL=https://api.github.com
+OPS_AI_ALLOWED_SCOPES=openg7-org,strapi,packages-contracts,packages-tooling,repository-root
+OPS_AI_ALLOWED_BASE_BRANCHES=main
+OPS_AI_TIMEOUT_MS=10000
+OPS_AI_COPILOT_DISPATCH_ENABLED=false
+OPS_AI_COPILOT_GITHUB_WORKFLOW=copilot-pr.yml
+OPS_AI_COPILOT_GITHUB_REF=main
+OPS_AI_CLAUDE_DISPATCH_ENABLED=false
+OPS_AI_CLAUDE_GITHUB_WORKFLOW=claude-pr.yml
+OPS_AI_CLAUDE_GITHUB_REF=main
+OPS_AI_GEMINI_DISPATCH_ENABLED=false
+OPS_AI_GEMINI_GITHUB_WORKFLOW=gemini-pr.yml
+OPS_AI_GEMINI_GITHUB_REF=main
+
 # Email transactionnel (HostPapa SMTP)
 # HostPapa supporte typiquement mail.papamail.net:465 (SSL) ou 587 (STARTTLS).
 # Si votre domaine publie son propre endpoint, utilisez par exemple mail.openg7.org.

--- a/strapi/scripts/test-admin-ops-api-integration.js
+++ b/strapi/scripts/test-admin-ops-api-integration.js
@@ -12,6 +12,7 @@ const OPS_ACTIONS = [
   'api::admin-ops.admin-ops.backups',
   'api::admin-ops.admin-ops.imports',
   'api::admin-ops.admin-ops.security',
+  'api::admin-ops.admin-ops.proofs',
   'api::admin-ops.admin-ops.dispatchCodexWorkflow',
 ];
 
@@ -40,6 +41,14 @@ function applyTestEnvironment() {
   process.env.OPS_CODEX_ALLOWED_SCOPES = 'openg7-org,strapi';
   process.env.OPS_CODEX_ALLOWED_BASE_BRANCHES = 'main,develop';
   process.env.OPS_CODEX_GITHUB_API_URL = 'https://api.github.test';
+  process.env.OPS_AI_GITHUB_TOKEN = 'ghs_admin_ops_test_token';
+  process.env.OPS_AI_GITHUB_OWNER = 'OpenG7';
+  process.env.OPS_AI_GITHUB_REPO = 'openg7-platform';
+  process.env.OPS_AI_GITHUB_API_URL = 'https://api.github.test';
+  process.env.OPS_AI_ALLOWED_SCOPES = 'openg7-org,strapi';
+  process.env.OPS_AI_ALLOWED_BASE_BRANCHES = 'main,develop';
+  process.env.OPS_AI_COPILOT_DISPATCH_ENABLED = 'true';
+  process.env.OPS_AI_COPILOT_GITHUB_WORKFLOW = 'copilot-pr.yml';
 }
 
 async function cleanupDatabase() {
@@ -181,9 +190,196 @@ async function run() {
   const workflowDispatchCalls = [];
   global.fetch = async (input, init) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const parsedUrl = new URL(url);
+    if (url === 'https://api.github.test/repos/OpenG7/openg7-platform/actions/secrets?per_page=100') {
+      return new Response(
+        JSON.stringify({
+          total_count: 2,
+          secrets: [{ name: 'OPENAI_API_KEY' }, { name: 'ANTHROPIC_API_KEY' }],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/workflows/codex-pr.yml/runs')) {
+      return new Response(
+        JSON.stringify({
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 501,
+              run_number: 51,
+              html_url: 'https://github.com/OpenG7/openg7-platform/actions/runs/501',
+              status: 'completed',
+              conclusion: 'success',
+              head_branch: 'codex/qa-proof-501',
+              created_at: '2026-04-30T00:00:00.000Z',
+              updated_at: '2026-04-30T00:08:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/workflows/claude-pr.yml/runs')) {
+      return new Response(
+        JSON.stringify({
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 601,
+              run_number: 18,
+              html_url: 'https://github.com/OpenG7/openg7-platform/actions/runs/601',
+              status: 'in_progress',
+              conclusion: null,
+              head_branch: 'claude/qa-proof-601',
+              created_at: '2026-04-30T00:10:00.000Z',
+              updated_at: '2026-04-30T00:11:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/workflows/gemini-pr.yml/runs')) {
+      return new Response(
+        JSON.stringify({ total_count: 0, workflow_runs: [] }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/workflows/copilot-pr.yml/runs')) {
+      return new Response(
+        JSON.stringify({
+          total_count: 1,
+          workflow_runs: [
+            {
+              id: 701,
+              run_number: 7,
+              html_url: 'https://github.com/OpenG7/openg7-platform/actions/runs/701',
+              status: 'completed',
+              conclusion: 'failure',
+              head_branch: 'copilot/placeholder-701',
+              created_at: '2026-04-30T00:12:00.000Z',
+              updated_at: '2026-04-30T00:13:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/runs/501/artifacts')) {
+      return new Response(
+        JSON.stringify({
+          total_count: 2,
+          artifacts: [
+            {
+              id: 9001,
+              name: 'playwright-report',
+              size_in_bytes: 2048,
+              expired: false,
+            },
+            {
+              id: 9002,
+              name: 'logs',
+              size_in_bytes: 1024,
+              expired: false,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/runs/601/artifacts')) {
+      return new Response(
+        JSON.stringify({
+          total_count: 1,
+          artifacts: [
+            {
+              id: 9003,
+              name: 'draft-proof',
+              size_in_bytes: 512,
+              expired: false,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/actions/runs/701/artifacts')) {
+      return new Response(
+        JSON.stringify({ total_count: 0, artifacts: [] }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+    if (parsedUrl.pathname.endsWith('/pulls')) {
+      const head = parsedUrl.searchParams.get('head');
+      if (head === 'OpenG7:codex/qa-proof-501') {
+        return new Response(
+          JSON.stringify([
+            {
+              number: 321,
+              title: 'Codex QA proof package',
+              html_url: 'https://github.com/OpenG7/openg7-platform/pull/321',
+              state: 'open',
+              merged_at: null,
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+      if (head === 'OpenG7:claude/qa-proof-601') {
+        return new Response(
+          JSON.stringify([
+            {
+              number: 322,
+              title: 'Claude draft improvements',
+              html_url: 'https://github.com/OpenG7/openg7-platform/pull/322',
+              state: 'open',
+              merged_at: null,
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
     if (
       url ===
-      'https://api.github.test/repos/OpenG7/openg7-platform/actions/workflows/codex-pr.yml/dispatches'
+        'https://api.github.test/repos/OpenG7/openg7-platform/actions/workflows/codex-pr.yml/dispatches' ||
+      url ===
+        'https://api.github.test/repos/OpenG7/openg7-platform/actions/workflows/copilot-pr.yml/dispatches'
     ) {
       workflowDispatchCalls.push({ url, init });
       return new Response(null, { status: 204 });
@@ -251,11 +447,69 @@ async function run() {
       Array.isArray(security.body?.data?.uploads?.allowedMimeTypes),
       'Expected upload mime type list.'
     );
+    assert.ok(Array.isArray(security.body?.data?.aiKeys), 'Expected ignition console modules.');
+    assert.equal(
+      security.body?.data?.aiKeys?.find((entry) => entry.provider === 'codex')?.state,
+      'ready',
+      'Expected Codex bay to be lit when OPENAI_API_KEY is present.',
+    );
+    assert.equal(
+      security.body?.data?.aiKeys?.find((entry) => entry.provider === 'claude')?.state,
+      'ready',
+      'Expected Claude bay to be lit when ANTHROPIC_API_KEY is present.',
+    );
+    assert.equal(
+      security.body?.data?.aiKeys?.find((entry) => entry.provider === 'gemini')?.state,
+      'offline',
+      'Expected Gemini bay to stay dark while GEMINI_API_KEY is missing.',
+    );
+    assert.equal(
+      security.body?.data?.aiKeys?.find((entry) => entry.provider === 'copilot')?.state,
+      'unsupported',
+      'Expected Copilot bay to stay inactive until a stable key socket exists.',
+    );
 
-    const invalidCodexDispatch = await requestJson(`${baseUrl}/api/admin/ops/codex/dispatch`, {
+    const proofs = await requestJson(`${baseUrl}/api/admin/ops/ai/proofs`, {
+      headers: authHeaders(adminUser.jwt),
+    });
+    assert.equal(proofs.status, 200, 'Expected admin proofs endpoint access.');
+    assert.ok(Array.isArray(proofs.body?.data?.providers), 'Expected AI proof provider list.');
+    assert.equal(
+      proofs.body?.data?.providers?.find((entry) => entry.provider === 'codex')?.state,
+      'completed',
+      'Expected Codex latest proof package to be completed.',
+    );
+    assert.equal(
+      proofs.body?.data?.providers?.find((entry) => entry.provider === 'codex')?.artifacts?.length,
+      2,
+      'Expected Codex proof package artifacts to be exposed.',
+    );
+    assert.equal(
+      proofs.body?.data?.providers?.find((entry) => entry.provider === 'codex')?.pullRequest?.number,
+      321,
+      'Expected Codex latest proof package to surface its PR.',
+    );
+    assert.equal(
+      proofs.body?.data?.providers?.find((entry) => entry.provider === 'claude')?.state,
+      'in-progress',
+      'Expected Claude proof package to surface the in-progress run.',
+    );
+    assert.equal(
+      proofs.body?.data?.providers?.find((entry) => entry.provider === 'copilot')?.state,
+      'failed',
+      'Expected Copilot placeholder run to surface as failed evidence.',
+    );
+    assert.equal(
+      proofs.body?.data?.providers?.find((entry) => entry.provider === 'gemini')?.state,
+      'unavailable',
+      'Expected Gemini to show no proof package when no workflow run exists.',
+    );
+
+    const invalidCodexDispatch = await requestJson(`${baseUrl}/api/admin/ops/ai/dispatch`, {
       method: 'POST',
       headers: authHeaders(adminUser.jwt),
       body: JSON.stringify({
+        provider: 'copilot',
         task: 'Try an invalid scope.',
         scope: 'repository-root',
         baseBranch: 'main',
@@ -264,10 +518,11 @@ async function run() {
     });
     assert.equal(invalidCodexDispatch.status, 400, 'Expected invalid codex scope to be rejected.');
 
-    const codexDispatch = await requestJson(`${baseUrl}/api/admin/ops/codex/dispatch`, {
+    const copilotDispatch = await requestJson(`${baseUrl}/api/admin/ops/ai/dispatch`, {
       method: 'POST',
       headers: authHeaders(adminUser.jwt),
       body: JSON.stringify({
+        provider: 'copilot',
         task: 'Fix the login empty state and add a focused test.',
         scope: 'openg7-org',
         baseBranch: 'main',
@@ -276,17 +531,37 @@ async function run() {
         effort: 'medium',
       }),
     });
-    assert.equal(codexDispatch.status, 200, 'Expected codex dispatch endpoint access.');
-    assert.equal(codexDispatch.body?.data?.queued, true, 'Expected queued dispatch response.');
+    assert.equal(copilotDispatch.status, 200, 'Expected provider dispatch endpoint access.');
+    assert.equal(copilotDispatch.body?.data?.queued, true, 'Expected queued dispatch response.');
+    assert.equal(copilotDispatch.body?.data?.selectedProvider, 'copilot', 'Expected provider echo.');
     assert.equal(workflowDispatchCalls.length, 1, 'Expected one GitHub workflow dispatch call.');
 
     const dispatchedPayload = JSON.parse(String(workflowDispatchCalls[0]?.init?.body ?? '{}'));
     assert.equal(dispatchedPayload.ref, 'main', 'Expected configured GitHub ref.');
+    assert.equal(dispatchedPayload.inputs?.provider, 'copilot', 'Expected forwarded provider.');
     assert.equal(dispatchedPayload.inputs?.scope, 'openg7-org', 'Expected forwarded codex scope.');
     assert.equal(dispatchedPayload.inputs?.base_branch, 'main', 'Expected forwarded base branch.');
     assert.equal(dispatchedPayload.inputs?.draft_pr, 'true', 'Expected forwarded draft PR flag.');
     assert.equal(dispatchedPayload.inputs?.model, 'gpt-5.4', 'Expected forwarded model.');
     assert.equal(dispatchedPayload.inputs?.effort, 'medium', 'Expected forwarded effort.');
+    assert.equal(
+      workflowDispatchCalls[0]?.url,
+      'https://api.github.test/repos/OpenG7/openg7-platform/actions/workflows/copilot-pr.yml/dispatches',
+      'Expected the copilot workflow to be selected.',
+    );
+
+    const legacyCodexDispatch = await requestJson(`${baseUrl}/api/admin/ops/codex/dispatch`, {
+      method: 'POST',
+      headers: authHeaders(adminUser.jwt),
+      body: JSON.stringify({
+        task: 'Run the legacy Codex dispatch alias.',
+        scope: 'openg7-org',
+        baseBranch: 'main',
+        draftPr: true,
+      }),
+    });
+    assert.equal(legacyCodexDispatch.status, 200, 'Expected legacy codex alias to keep working.');
+    assert.equal(workflowDispatchCalls.length, 2, 'Expected legacy alias dispatch to trigger a second call.');
 
     const ownerHealth = await requestJson(`${baseUrl}/api/admin/ops/health`, {
       headers: authHeaders(ownerUser.jwt),

--- a/strapi/src/api/admin-ops/controllers/admin-ops.ts
+++ b/strapi/src/api/admin-ops/controllers/admin-ops.ts
@@ -16,18 +16,44 @@ const DEFAULT_UPLOAD_ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/web
 const DEFAULT_IMPORT_SCAN_LIMIT = 2000;
 const DEFAULT_SECURITY_SESSION_SCAN_LIMIT = 250;
 const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 12 * 60 * 60 * 1000;
-const DEFAULT_CODEX_GITHUB_API_URL = 'https://api.github.com';
-const DEFAULT_CODEX_GITHUB_WORKFLOW = 'codex-pr.yml';
-const DEFAULT_CODEX_GITHUB_REF = 'main';
-const DEFAULT_CODEX_TIMEOUT_MS = 10_000;
-const DEFAULT_CODEX_ALLOWED_SCOPES = [
+const DEFAULT_AI_GITHUB_API_URL = 'https://api.github.com';
+const DEFAULT_AI_GITHUB_REF = 'main';
+const DEFAULT_AI_TIMEOUT_MS = 10_000;
+const DEFAULT_AI_ALLOWED_SCOPES = [
   'openg7-org',
   'strapi',
   'packages-contracts',
   'packages-tooling',
   'repository-root',
 ] as const;
-const DEFAULT_CODEX_ALLOWED_BASE_BRANCHES = ['main'] as const;
+const DEFAULT_AI_ALLOWED_BASE_BRANCHES = ['main'] as const;
+const ADMIN_AI_PROVIDERS = ['codex', 'copilot', 'claude', 'gemini'] as const;
+
+type AdminAiProvider = (typeof ADMIN_AI_PROVIDERS)[number];
+
+const DEFAULT_AI_PROVIDER_WORKFLOWS: Readonly<Record<AdminAiProvider, string>> = {
+  codex: 'codex-pr.yml',
+  copilot: 'copilot-pr.yml',
+  claude: 'claude-pr.yml',
+  gemini: 'gemini-pr.yml',
+};
+
+const ADMIN_AI_PROVIDER_SECRET_NAMES: Readonly<Record<AdminAiProvider, string | null>> = {
+  codex: 'OPENAI_API_KEY',
+  copilot: null,
+  claude: 'ANTHROPIC_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+};
+
+const ADMIN_AI_PROVIDER_LABELS: Readonly<Record<AdminAiProvider, string>> = {
+  codex: 'Codex',
+  copilot: 'GitHub Copilot',
+  claude: 'Claude',
+  gemini: 'Gemini',
+};
+
+type AiIgnitionState = 'ready' | 'offline' | 'scan-unavailable' | 'unsupported';
+type AiProofState = 'queued' | 'in-progress' | 'completed' | 'failed' | 'unavailable';
 
 interface BackupFileEntry {
   readonly name: string;
@@ -52,7 +78,8 @@ interface ImportedCompanyLike {
   readonly updatedAt?: unknown;
 }
 
-interface CodexDispatchConfig {
+interface AiDispatchConfig {
+  readonly selectedProvider: AdminAiProvider;
   readonly enabled: boolean;
   readonly configured: boolean;
   readonly apiUrl: string;
@@ -66,13 +93,72 @@ interface CodexDispatchConfig {
   readonly allowedBaseBranches: string[];
 }
 
-interface CodexDispatchInput {
+interface AiDispatchInput {
+  readonly provider: AdminAiProvider;
   readonly task: string;
   readonly scope: string;
   readonly baseBranch: string;
   readonly draftPr: boolean;
   readonly model: string | null;
   readonly effort: string | null;
+}
+
+interface AiIgnitionModuleSnapshot {
+  readonly provider: AdminAiProvider;
+  readonly label: string;
+  readonly workflow: string;
+  readonly secretName: string | null;
+  readonly dispatchEnabled: boolean;
+  readonly keyInserted: boolean;
+  readonly state: AiIgnitionState;
+  readonly note: string;
+}
+
+interface AiProofArtifactSnapshot {
+  readonly id: number | null;
+  readonly name: string;
+  readonly sizeBytes: number;
+  readonly expired: boolean;
+  readonly url: string | null;
+}
+
+interface AiProofPullRequestSnapshot {
+  readonly number: number | null;
+  readonly title: string;
+  readonly url: string | null;
+  readonly state: string;
+  readonly merged: boolean;
+  readonly branch: string | null;
+}
+
+interface AiProofRunSnapshot {
+  readonly id: number | null;
+  readonly number: number | null;
+  readonly url: string | null;
+  readonly status: string | null;
+  readonly conclusion: string | null;
+  readonly branch: string | null;
+  readonly createdAt: string | null;
+  readonly updatedAt: string | null;
+}
+
+interface AiProofProviderSnapshot {
+  readonly provider: AdminAiProvider;
+  readonly label: string;
+  readonly workflow: string;
+  readonly state: AiProofState;
+  readonly summary: string;
+  readonly run: AiProofRunSnapshot | null;
+  readonly artifacts: AiProofArtifactSnapshot[];
+  readonly pullRequest: AiProofPullRequestSnapshot | null;
+}
+
+interface GitHubWorkflowRunListPayload {
+  readonly workflow_runs?: Array<Record<string, unknown>>;
+}
+
+interface GitHubArtifactsListPayload {
+  readonly artifacts?: Array<Record<string, unknown>>;
 }
 
 function normalizeString(value: unknown, maxLength = 320): string | null {
@@ -106,6 +192,16 @@ function normalizeWorkflowToken(value: unknown, maxLength = 160): string | null 
     return null;
   }
   return normalized;
+}
+
+function normalizeAiProvider(value: unknown): AdminAiProvider | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return ADMIN_AI_PROVIDERS.includes(normalized as AdminAiProvider)
+    ? (normalized as AdminAiProvider)
+    : null;
 }
 
 function normalizeInteger(value: unknown): number | null {
@@ -148,6 +244,23 @@ function parseBoolean(value: unknown, fallback: boolean): boolean {
   return fallback;
 }
 
+function normalizeBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return null;
+}
+
 function parseDelimitedLowerStrings(value: unknown): string[] {
   if (typeof value !== 'string') {
     return [];
@@ -180,6 +293,431 @@ function parseDelimitedWorkflowTokens(value: unknown): string[] {
   }
 
   return Array.from(unique);
+}
+
+function resolveNormalizedText(values: ReadonlyArray<unknown>, maxLength = 320): string | null {
+  for (const value of values) {
+    const normalized = normalizeText(value, maxLength);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function resolveWorkflowTokenValue(values: ReadonlyArray<unknown>, maxLength = 160): string | null {
+  for (const value of values) {
+    const normalized = normalizeWorkflowToken(value, maxLength);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function resolveBooleanValue(values: ReadonlyArray<unknown>): boolean | null {
+  for (const value of values) {
+    const normalized = normalizeBoolean(value);
+    if (normalized != null) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function resolvePositiveIntegerValue(values: ReadonlyArray<unknown>, fallback: number): number {
+  for (const value of values) {
+    const parsed = normalizeInteger(value);
+    if (parsed != null && parsed > 0) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function resolveDelimitedLowerStrings(values: ReadonlyArray<unknown>): string[] {
+  for (const value of values) {
+    const parsed = parseDelimitedLowerStrings(value);
+    if (parsed.length > 0) {
+      return parsed;
+    }
+  }
+  return [];
+}
+
+function resolveDelimitedWorkflowTokens(values: ReadonlyArray<unknown>): string[] {
+  for (const value of values) {
+    const parsed = parseDelimitedWorkflowTokens(value);
+    if (parsed.length > 0) {
+      return parsed;
+    }
+  }
+  return [];
+}
+
+function aiProviderEnvKey(provider: AdminAiProvider, suffix: string): string {
+  return `OPS_AI_${provider.toUpperCase()}_${suffix}`;
+}
+
+function resolveAiSecretsProbeConfig(): {
+  apiUrl: string;
+  owner: string;
+  repo: string;
+  token: string;
+} | null {
+  for (const provider of ADMIN_AI_PROVIDERS) {
+    const config = getAiDispatchConfig(provider);
+    if (config.token && config.owner && config.repo) {
+      return {
+        apiUrl: config.apiUrl,
+        owner: config.owner,
+        repo: config.repo,
+        token: config.token,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function fetchGitHubActionsSecretNames(): Promise<Set<string> | null> {
+  const probe = resolveAiSecretsProbeConfig();
+  if (!probe) {
+    return null;
+  }
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), DEFAULT_AI_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      `${probe.apiUrl}/repos/${probe.owner}/${probe.repo}/actions/secrets?per_page=100`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${probe.token}`,
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'openg7-admin-ops',
+        },
+        signal: abortController.signal,
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as { secrets?: Array<{ name?: unknown }> };
+    const secretNames = new Set<string>();
+
+    for (const secret of Array.isArray(payload.secrets) ? payload.secrets : []) {
+      const normalized = normalizeWorkflowToken(secret?.name, 160);
+      if (normalized) {
+        secretNames.add(normalized);
+      }
+    }
+
+    return secretNames;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchGitHubJson<T>(config: AiDispatchConfig, endpoint: string): Promise<T | null> {
+  if (!config.token || !config.owner || !config.repo) {
+    return null;
+  }
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), config.timeoutMs);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${config.token}`,
+        'User-Agent': 'openg7-admin-ops',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: abortController.signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function normalizeUrl(value: unknown): string | null {
+  const normalized = normalizeText(value, 500);
+  if (!normalized) {
+    return null;
+  }
+
+  return /^https?:\/\//i.test(normalized) ? normalized : null;
+}
+
+function parseAiProofRun(value: unknown): AiProofRunSnapshot | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return {
+    id: normalizeInteger(record.id),
+    number: normalizeInteger(record.run_number),
+    url: normalizeUrl(record.html_url),
+    status: normalizeText(record.status, 80),
+    conclusion: normalizeText(record.conclusion, 80),
+    branch: normalizeText(record.head_branch, 160),
+    createdAt: normalizeIsoDate(record.created_at),
+    updatedAt: normalizeIsoDate(record.updated_at),
+  };
+}
+
+async function fetchLatestWorkflowRun(
+  config: AiDispatchConfig,
+): Promise<AiProofRunSnapshot | null> {
+  if (!config.owner || !config.repo) {
+    return null;
+  }
+
+  const runsUrl = new URL(
+    `${config.apiUrl}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/actions/workflows/${encodeURIComponent(config.workflow)}/runs`,
+  );
+  runsUrl.searchParams.set('per_page', '1');
+  runsUrl.searchParams.set('branch', config.ref);
+  runsUrl.searchParams.set('event', 'workflow_dispatch');
+
+  const payload = await fetchGitHubJson<GitHubWorkflowRunListPayload>(config, runsUrl.toString());
+  const run = payload?.workflow_runs?.[0];
+  return parseAiProofRun(run);
+}
+
+async function fetchWorkflowRunArtifacts(
+  config: AiDispatchConfig,
+  run: AiProofRunSnapshot,
+): Promise<AiProofArtifactSnapshot[]> {
+  if (!config.owner || !config.repo || run.id == null) {
+    return [];
+  }
+
+  const artifactsUrl = `${config.apiUrl}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/actions/runs/${run.id}/artifacts`;
+  const payload = await fetchGitHubJson<GitHubArtifactsListPayload>(config, artifactsUrl);
+
+  return Array.isArray(payload?.artifacts)
+    ? payload.artifacts.map((artifact) => {
+        const artifactRecord = artifact as Record<string, unknown>;
+        return {
+          id: normalizeInteger(artifactRecord.id),
+          name: normalizeText(artifactRecord.name, 180) ?? 'artifact',
+          sizeBytes: Math.max(0, normalizeInteger(artifactRecord.size_in_bytes) ?? 0),
+          expired: Boolean(artifactRecord.expired),
+          url: run.url ? `${run.url}#artifacts` : null,
+        };
+      })
+    : [];
+}
+
+async function fetchPullRequestForBranch(
+  config: AiDispatchConfig,
+  branch: string,
+): Promise<AiProofPullRequestSnapshot | null> {
+  if (!config.owner || !config.repo) {
+    return null;
+  }
+
+  const pullsUrl = new URL(
+    `${config.apiUrl}/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/pulls`,
+  );
+  pullsUrl.searchParams.set('head', `${config.owner}:${branch}`);
+  pullsUrl.searchParams.set('state', 'all');
+  pullsUrl.searchParams.set('per_page', '5');
+
+  const payload = await fetchGitHubJson<Array<Record<string, unknown>>>(
+    config,
+    pullsUrl.toString(),
+  );
+  const pull = Array.isArray(payload) ? payload[0] : null;
+  if (!pull) {
+    return null;
+  }
+
+  return {
+    number: normalizeInteger(pull.number),
+    title: normalizeText(pull.title, 200) ?? 'Pull request',
+    url: normalizeUrl(pull.html_url),
+    state: normalizeText(pull.state, 40) ?? 'unknown',
+    merged: Boolean(pull.merged_at),
+    branch,
+  };
+}
+
+function resolveAiProofState(
+  run: AiProofRunSnapshot | null,
+  artifacts: readonly AiProofArtifactSnapshot[],
+): AiProofState {
+  if (!run?.status) {
+    return 'unavailable';
+  }
+
+  if (run.status === 'queued' || run.status === 'waiting') {
+    return 'queued';
+  }
+
+  if (run.status === 'in_progress' || run.status === 'requested' || run.status === 'pending') {
+    return 'in-progress';
+  }
+
+  if (run.status === 'completed') {
+    return run.conclusion === 'success' && artifacts.length >= 0 ? 'completed' : 'failed';
+  }
+
+  return 'unavailable';
+}
+
+function buildAiProofSummary(
+  state: AiProofState,
+  workflow: string,
+  run: AiProofRunSnapshot | null,
+  artifacts: readonly AiProofArtifactSnapshot[],
+  pullRequest: AiProofPullRequestSnapshot | null,
+): string {
+  if (!run) {
+    return `No workflow run detected yet for ${workflow}.`;
+  }
+
+  switch (state) {
+    case 'queued':
+      return `Workflow #${run.number ?? 'n/a'} is queued on ${run.branch ?? 'the last branch'}.`;
+    case 'in-progress':
+      return `Workflow #${run.number ?? 'n/a'} is executing on ${run.branch ?? 'the active branch'}.`;
+    case 'completed':
+      return `Workflow #${run.number ?? 'n/a'} completed with ${artifacts.length} artifact(s)${pullRequest ? ` and PR #${pullRequest.number ?? 'n/a'}` : ''}.`;
+    case 'failed':
+      return `Workflow #${run.number ?? 'n/a'} finished with conclusion ${run.conclusion ?? 'unknown'}.`;
+    default:
+      return `GitHub evidence is unavailable for ${workflow}.`;
+  }
+}
+
+async function buildAiProofProviders(): Promise<AiProofProviderSnapshot[]> {
+  return Promise.all(
+    ADMIN_AI_PROVIDERS.map(async (provider) => {
+      const config = getAiDispatchConfig(provider);
+      const baseSnapshot = {
+        provider,
+        label: ADMIN_AI_PROVIDER_LABELS[provider],
+        workflow: config.workflow,
+      } as const;
+
+      if (!config.configured) {
+        return {
+          ...baseSnapshot,
+          state: 'unavailable' as const,
+          summary: 'GitHub workflow monitoring is not configured for this provider.',
+          run: null,
+          artifacts: [],
+          pullRequest: null,
+        };
+      }
+
+      try {
+        const run = await fetchLatestWorkflowRun(config);
+        if (!run) {
+          return {
+            ...baseSnapshot,
+            state: 'unavailable' as const,
+            summary: `No workflow run detected yet for ${config.workflow}.`,
+            run: null,
+            artifacts: [],
+            pullRequest: null,
+          };
+        }
+
+        const [artifacts, pullRequest] = await Promise.all([
+          fetchWorkflowRunArtifacts(config, run),
+          run.branch ? fetchPullRequestForBranch(config, run.branch) : Promise.resolve(null),
+        ]);
+        const state = resolveAiProofState(run, artifacts);
+
+        return {
+          ...baseSnapshot,
+          state,
+          summary: buildAiProofSummary(state, config.workflow, run, artifacts, pullRequest),
+          run,
+          artifacts,
+          pullRequest,
+        };
+      } catch {
+        return {
+          ...baseSnapshot,
+          state: 'unavailable' as const,
+          summary: `GitHub evidence is unavailable for ${config.workflow}.`,
+          run: null,
+          artifacts: [],
+          pullRequest: null,
+        };
+      }
+    }),
+  );
+}
+
+async function buildAiProofSnapshot() {
+  return {
+    generatedAt: new Date().toISOString(),
+    providers: await buildAiProofProviders(),
+  };
+}
+
+async function buildAiIgnitionModules(): Promise<AiIgnitionModuleSnapshot[]> {
+  const repoSecretNames = await fetchGitHubActionsSecretNames();
+
+  return ADMIN_AI_PROVIDERS.map((provider) => {
+    const config = getAiDispatchConfig(provider);
+    const secretName = ADMIN_AI_PROVIDER_SECRET_NAMES[provider];
+    const keyInserted = Boolean(secretName && repoSecretNames?.has(secretName));
+
+    let state: AiIgnitionState;
+    let note: string;
+
+    if (!secretName) {
+      state = 'unsupported';
+      note = 'No stable ignition key is wired for this console yet.';
+    } else if (repoSecretNames == null) {
+      state = 'scan-unavailable';
+      note = 'The control plane could not verify GitHub Actions secrets for this module.';
+    } else if (keyInserted) {
+      state = 'ready';
+      note = config.enabled
+        ? 'Key detected. The engine bay is armed and ready for dispatch.'
+        : 'Key detected. The engine bay stays in standby until dispatch is enabled.';
+    } else {
+      state = 'offline';
+      note = `Insert ${secretName} into GitHub Actions secrets to power this module.`;
+    }
+
+    return {
+      provider,
+      label: ADMIN_AI_PROVIDER_LABELS[provider],
+      workflow: config.workflow,
+      secretName,
+      dispatchEnabled: config.enabled,
+      keyInserted,
+      state,
+      note,
+    };
+  });
 }
 
 function normalizeIsoDate(value: unknown): string | null {
@@ -258,42 +796,103 @@ function respondHttpError(ctx: Context, status: number, name: string, message: s
   };
 }
 
-function getCodexDispatchConfig(): CodexDispatchConfig {
-  const allowedScopes = parseDelimitedLowerStrings(process.env.OPS_CODEX_ALLOWED_SCOPES);
-  const allowedBaseBranches = parseDelimitedWorkflowTokens(
-    process.env.OPS_CODEX_ALLOWED_BASE_BRANCHES,
+function getAiDispatchConfig(provider: AdminAiProvider): AiDispatchConfig {
+  const isCodex = provider === 'codex';
+  const allowedScopes = resolveDelimitedLowerStrings([
+    process.env[aiProviderEnvKey(provider, 'ALLOWED_SCOPES')],
+    process.env.OPS_AI_ALLOWED_SCOPES,
+    isCodex ? process.env.OPS_CODEX_ALLOWED_SCOPES : null,
+  ]);
+  const allowedBaseBranches = resolveDelimitedWorkflowTokens([
+    process.env[aiProviderEnvKey(provider, 'ALLOWED_BASE_BRANCHES')],
+    process.env.OPS_AI_ALLOWED_BASE_BRANCHES,
+    isCodex ? process.env.OPS_CODEX_ALLOWED_BASE_BRANCHES : null,
+  ]);
+  const token = resolveNormalizedText(
+    [
+      process.env[aiProviderEnvKey(provider, 'GITHUB_TOKEN')],
+      process.env.OPS_AI_GITHUB_TOKEN,
+      process.env.OPS_CODEX_GITHUB_TOKEN,
+    ],
+    500,
   );
-  const token = normalizeText(process.env.OPS_CODEX_GITHUB_TOKEN, 500);
-  const owner = normalizeWorkflowToken(process.env.OPS_CODEX_GITHUB_OWNER, 120);
-  const repo = normalizeWorkflowToken(process.env.OPS_CODEX_GITHUB_REPO, 120);
+  const owner = resolveWorkflowTokenValue(
+    [
+      process.env[aiProviderEnvKey(provider, 'GITHUB_OWNER')],
+      process.env.OPS_AI_GITHUB_OWNER,
+      process.env.OPS_CODEX_GITHUB_OWNER,
+    ],
+    120,
+  );
+  const repo = resolveWorkflowTokenValue(
+    [
+      process.env[aiProviderEnvKey(provider, 'GITHUB_REPO')],
+      process.env.OPS_AI_GITHUB_REPO,
+      process.env.OPS_CODEX_GITHUB_REPO,
+    ],
+    120,
+  );
+  const workflow =
+    resolveWorkflowTokenValue(
+      [
+        process.env[aiProviderEnvKey(provider, 'GITHUB_WORKFLOW')],
+        isCodex ? process.env.OPS_CODEX_GITHUB_WORKFLOW : null,
+      ],
+      160,
+    ) ?? DEFAULT_AI_PROVIDER_WORKFLOWS[provider];
+  const ref =
+    resolveWorkflowTokenValue(
+      [
+        process.env[aiProviderEnvKey(provider, 'GITHUB_REF')],
+        process.env.OPS_AI_GITHUB_REF,
+        isCodex ? process.env.OPS_CODEX_GITHUB_REF : null,
+      ],
+      160,
+    ) ?? DEFAULT_AI_GITHUB_REF;
 
   return {
-    enabled: parseBoolean(process.env.OPS_CODEX_DISPATCH_ENABLED, false),
-    configured: Boolean(token && owner && repo),
+    selectedProvider: provider,
+    enabled:
+      resolveBooleanValue([
+        process.env[aiProviderEnvKey(provider, 'DISPATCH_ENABLED')],
+        process.env.OPS_AI_DISPATCH_ENABLED,
+        isCodex ? process.env.OPS_CODEX_DISPATCH_ENABLED : null,
+      ]) ?? false,
+    configured: Boolean(token && owner && repo && workflow),
     apiUrl:
-      normalizeText(process.env.OPS_CODEX_GITHUB_API_URL, 500)?.replace(/\/+$/, '') ??
-      DEFAULT_CODEX_GITHUB_API_URL,
+      resolveNormalizedText(
+        [
+          process.env[aiProviderEnvKey(provider, 'GITHUB_API_URL')],
+          process.env.OPS_AI_GITHUB_API_URL,
+          process.env.OPS_CODEX_GITHUB_API_URL,
+        ],
+        500,
+      )?.replace(/\/+$/, '') ?? DEFAULT_AI_GITHUB_API_URL,
     owner,
     repo,
-    workflow:
-      normalizeWorkflowToken(process.env.OPS_CODEX_GITHUB_WORKFLOW, 160) ??
-      DEFAULT_CODEX_GITHUB_WORKFLOW,
-    ref: normalizeWorkflowToken(process.env.OPS_CODEX_GITHUB_REF, 160) ?? DEFAULT_CODEX_GITHUB_REF,
+    workflow,
+    ref,
     token,
-    timeoutMs: parsePositiveInteger(process.env.OPS_CODEX_TIMEOUT_MS, DEFAULT_CODEX_TIMEOUT_MS),
-    allowedScopes:
-      allowedScopes.length > 0 ? allowedScopes : Array.from(DEFAULT_CODEX_ALLOWED_SCOPES),
+    timeoutMs: resolvePositiveIntegerValue(
+      [
+        process.env[aiProviderEnvKey(provider, 'TIMEOUT_MS')],
+        process.env.OPS_AI_TIMEOUT_MS,
+        process.env.OPS_CODEX_TIMEOUT_MS,
+      ],
+      DEFAULT_AI_TIMEOUT_MS,
+    ),
+    allowedScopes: allowedScopes.length > 0 ? allowedScopes : Array.from(DEFAULT_AI_ALLOWED_SCOPES),
     allowedBaseBranches:
       allowedBaseBranches.length > 0
         ? allowedBaseBranches
-        : Array.from(DEFAULT_CODEX_ALLOWED_BASE_BRANCHES),
+        : Array.from(DEFAULT_AI_ALLOWED_BASE_BRANCHES),
   };
 }
 
-function validateCodexDispatchInput(
+function validateAiDispatchInput(
   body: unknown,
-  config: CodexDispatchConfig,
-): { input: CodexDispatchInput | null; error: string | null } {
+  config: AiDispatchConfig,
+): { input: AiDispatchInput | null; error: string | null } {
   const record =
     body && typeof body === 'object' && !Array.isArray(body)
       ? (body as Record<string, unknown>)
@@ -302,7 +901,16 @@ function validateCodexDispatchInput(
   if (!record) {
     return {
       input: null,
-      error: 'owner.ops.codex.payload.invalid',
+      error: 'owner.ops.ai.payload.invalid',
+    };
+  }
+
+  const provider =
+    record.provider == null ? config.selectedProvider : normalizeAiProvider(record.provider);
+  if (!provider) {
+    return {
+      input: null,
+      error: 'owner.ops.ai.provider.invalid',
     };
   }
 
@@ -310,7 +918,7 @@ function validateCodexDispatchInput(
   if (!task) {
     return {
       input: null,
-      error: 'owner.ops.codex.task.required',
+      error: 'owner.ops.ai.task.required',
     };
   }
 
@@ -318,7 +926,7 @@ function validateCodexDispatchInput(
   if (!scope || !config.allowedScopes.includes(scope)) {
     return {
       input: null,
-      error: 'owner.ops.codex.scope.invalid',
+      error: 'owner.ops.ai.scope.invalid',
     };
   }
 
@@ -326,12 +934,13 @@ function validateCodexDispatchInput(
   if (!baseBranch || !config.allowedBaseBranches.includes(baseBranch)) {
     return {
       input: null,
-      error: 'owner.ops.codex.base_branch.invalid',
+      error: 'owner.ops.ai.base_branch.invalid',
     };
   }
 
   return {
     input: {
+      provider,
       task,
       scope,
       baseBranch,
@@ -343,12 +952,12 @@ function validateCodexDispatchInput(
   };
 }
 
-async function dispatchCodexWorkflow(
-  config: CodexDispatchConfig,
-  input: CodexDispatchInput,
+async function dispatchAiWorkflow(
+  config: AiDispatchConfig,
+  input: AiDispatchInput,
 ): Promise<Record<string, unknown>> {
   if (!config.token || !config.owner || !config.repo) {
-    throw new Error('Codex GitHub dispatch is not configured.');
+    throw new Error(`${config.selectedProvider} GitHub dispatch is not configured.`);
   }
 
   const abortController = new AbortController();
@@ -373,6 +982,7 @@ async function dispatchCodexWorkflow(
       body: JSON.stringify({
         ref: config.ref,
         inputs: {
+          provider: input.provider,
           task: input.task,
           scope: input.scope,
           base_branch: input.baseBranch,
@@ -391,12 +1001,14 @@ async function dispatchCodexWorkflow(
     return {
       queued: true,
       provider: 'github-actions',
+      selectedProvider: config.selectedProvider,
       owner: config.owner,
       repo: config.repo,
       workflow: config.workflow,
       ref: config.ref,
       requestedAt: new Date().toISOString(),
       request: {
+        selectedProvider: input.provider,
         scope: input.scope,
         baseBranch: input.baseBranch,
         draftPr: input.draftPr,
@@ -736,6 +1348,7 @@ async function buildSecuritySnapshot(strapi: Core.Strapi) {
     }
     return DEFAULT_UPLOAD_ALLOWED_MIME_TYPES;
   })();
+  const aiKeys = await buildAiIgnitionModules();
 
   return {
     generatedAt: new Date().toISOString(),
@@ -759,6 +1372,7 @@ async function buildSecuritySnapshot(strapi: Core.Strapi) {
     auth: {
       sessionIdleTimeoutMs: parseSessionIdleTimeoutMs(process.env.AUTH_SESSION_IDLE_TIMEOUT_MS),
     },
+    aiKeys,
     moderation: {
       pendingCompanies,
       suspendedCompanies,
@@ -803,31 +1417,54 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     }
   },
 
-  async dispatchCodexWorkflow(ctx: Context) {
-    const config = getCodexDispatchConfig();
+  async proofs(ctx: Context) {
+    try {
+      ctx.body = { data: await buildAiProofSnapshot() };
+    } catch (error: unknown) {
+      strapi.log.error(`[ops] Failed to build AI proof snapshot: ${toErrorMessage(error)}`);
+      ctx.internalServerError('owner.ops.ai.proofs.failed');
+    }
+  },
 
-    if (!config.enabled || !config.configured) {
-      strapi.log.warn('[ops] Codex workflow dispatch requested while integration is disabled.');
-      respondHttpError(ctx, 503, 'ServiceUnavailableError', 'owner.ops.codex.disabled');
+  async dispatchCodexWorkflow(ctx: Context) {
+    const body = (ctx.request as Context['request']).body;
+    const record =
+      body && typeof body === 'object' && !Array.isArray(body)
+        ? (body as Record<string, unknown>)
+        : null;
+    const requestedProvider =
+      record?.provider == null ? 'codex' : normalizeAiProvider(record.provider);
+
+    if (record?.provider != null && !requestedProvider) {
+      ctx.badRequest('owner.ops.ai.provider.invalid');
       return;
     }
 
-    const { input, error } = validateCodexDispatchInput(
-      (ctx.request as Context['request']).body,
-      config,
-    );
+    const config = getAiDispatchConfig(requestedProvider ?? 'codex');
+
+    if (!config.enabled || !config.configured) {
+      strapi.log.warn(
+        `[ops] ${config.selectedProvider} workflow dispatch requested while integration is disabled.`,
+      );
+      respondHttpError(ctx, 503, 'ServiceUnavailableError', 'owner.ops.ai.disabled');
+      return;
+    }
+
+    const { input, error } = validateAiDispatchInput(body, config);
     if (error || !input) {
-      ctx.badRequest(error ?? 'owner.ops.codex.payload.invalid');
+      ctx.badRequest(error ?? 'owner.ops.ai.payload.invalid');
       return;
     }
 
     try {
       ctx.body = {
-        data: await dispatchCodexWorkflow(config, input),
+        data: await dispatchAiWorkflow(config, input),
       };
     } catch (error: unknown) {
-      strapi.log.error(`[ops] Failed to dispatch Codex workflow: ${toErrorMessage(error)}`);
-      respondHttpError(ctx, 502, 'BadGatewayError', 'owner.ops.codex.dispatch.failed');
+      strapi.log.error(
+        `[ops] Failed to dispatch ${config.selectedProvider} workflow: ${toErrorMessage(error)}`,
+      );
+      respondHttpError(ctx, 502, 'BadGatewayError', 'owner.ops.ai.dispatch.failed');
     }
   },
 });

--- a/strapi/src/api/admin-ops/routes/admin-ops.ts
+++ b/strapi/src/api/admin-ops/routes/admin-ops.ts
@@ -33,6 +33,22 @@ export default {
       },
     },
     {
+      method: 'GET',
+      path: '/admin/ops/ai/proofs',
+      handler: 'admin-ops.proofs',
+      config: {
+        policies: ['global::owner-admin-ops'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/admin/ops/ai/dispatch',
+      handler: 'admin-ops.dispatchCodexWorkflow',
+      config: {
+        policies: ['global::owner-admin-ops'],
+      },
+    },
+    {
       method: 'POST',
       path: '/admin/ops/codex/dispatch',
       handler: 'admin-ops.dispatchCodexWorkflow',


### PR DESCRIPTION
- Added new GET and POST routes for AI operations in admin-ops.
- Introduced GitHub Actions workflows for Claude, Copilot, and Gemini to automate branch creation and PR submission.
- Created a new data access file for managing AI provider options and defaults.

## Summary
Describe the change (scope, motivation, user or technical impact).

## Details / decisions
- Design choices or tradeoffs
- Documentation or configuration impact

## Anti-duplication checklist
- [ ] I reviewed docs/ecosystem/ECOSYSTEM-MAP.md
- [ ] I confirmed whether this capability already has a canonical repo
- [ ] If reusable by 2+ repos, I proposed a shared @openg7/* package instead of copy/paste
- [ ] I did not introduce canonical domain logic into openg7-nexus

## Tests
- [ ] `yarn lint`
- [ ] `yarn format:check`
- [ ] `yarn validate:selectors`
- [ ] `yarn codegen && yarn test`
- [ ] `yarn predeploy:cms-cache`
- [ ] `yarn prebuild:web`
- [ ] Other (specify):

## Review
- [ ] Docs updated (README, docs, or comments)
- [ ] Screenshot attached if UI
- [ ] Linked issue referenced
