### PR TITLE
fix: reorder imports for consistency in feed-indicator-detail and hom…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ strapi/data/db.sqlite
 **/build/
 **/coverage/
 **/*.js
+!strapi/scripts/test-*.js
 **/*.js.map
 *.tsbuildinfo
 docs/reference/

--- a/openg7-org/src/app/domains/feed/feature/pages/feed-indicator-detail.page.ts
+++ b/openg7-org/src/app/domains/feed/feature/pages/feed-indicator-detail.page.ts
@@ -1,5 +1,4 @@
 import { CommonModule } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -9,6 +8,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '@app/core/auth/auth.service';
 import { resolveCorridorContext } from '@app/core/config/corridor-context';

--- a/openg7-org/src/app/domains/home/feature/home-corridors-realtime/home-corridors-realtime.component.spec.ts
+++ b/openg7-org/src/app/domains/home/feature/home-corridors-realtime/home-corridors-realtime.component.spec.ts
@@ -1,12 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
-
 import {
   CorridorsRealtimeSnapshot,
   HomeCorridorsRealtimeService,
 } from '@app/domains/home/services/home-corridors-realtime.service';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
 import { HomeCorridorsRealtimeComponent } from './home-corridors-realtime.component';
 

--- a/strapi/scripts/test-admin-quality-matrix-api-integration.js
+++ b/strapi/scripts/test-admin-quality-matrix-api-integration.js
@@ -1,0 +1,183 @@
+/* eslint-disable no-console */
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { compileStrapi, createStrapi } = require('@strapi/strapi');
+
+const TEST_DB_FILENAME = `db.admin-quality-matrix.integration.${process.pid}.${Date.now()}.sqlite`;
+const MATRIX_ENTRY_UID = 'api::admin-quality-matrix.admin-quality-matrix-entry';
+
+function applyTestEnvironment() {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+  process.env.STRAPI_ENV = process.env.STRAPI_ENV || 'test';
+  process.env.STRAPI_SEED_AUTO = 'false';
+  process.env.DATABASE_CLIENT = 'sqlite';
+  process.env.DATABASE_FILENAME = TEST_DB_FILENAME;
+  process.env.HOST = '127.0.0.1';
+  process.env.PORT = '0';
+  process.env.APP_KEYS = process.env.APP_KEYS || 'admin-quality-matrix-test-app-key-a,admin-quality-matrix-test-app-key-b';
+  process.env.API_TOKEN_SALT = process.env.API_TOKEN_SALT || 'admin-quality-matrix-test-api-token-salt';
+  process.env.ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'admin-quality-matrix-test-admin-jwt-secret';
+  process.env.TRANSFER_TOKEN_SALT = process.env.TRANSFER_TOKEN_SALT || 'admin-quality-matrix-test-transfer-token-salt';
+  process.env.JWT_SECRET = process.env.JWT_SECRET || 'admin-quality-matrix-test-jwt-secret';
+  process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'admin-quality-matrix-test-encryption-key-123456789';
+  process.env.STRAPI_ADMIN_QUALITY_INGEST_TOKEN = 'matrix-ingest-test-token';
+}
+
+async function cleanupDatabase() {
+  const basePath = path.join(__dirname, '..', 'data', TEST_DB_FILENAME);
+  const candidates = [basePath, `${basePath}-wal`, `${basePath}-shm`];
+  await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        await fs.rm(candidate, { force: true });
+      } catch {
+        // Ignore cleanup errors.
+      }
+    }),
+  );
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = null;
+    }
+  }
+  return { response, status: response.status, body, text };
+}
+
+function authHeaders(extra = {}) {
+  return {
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+}
+
+function normalizeFindManyResult(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [value];
+}
+
+async function createMatrixEntry(strapi, entryId) {
+  return strapi.entityService.create(MATRIX_ENTRY_UID, {
+    data: {
+      entryId,
+      domain: 'Trust et validation',
+      need: 'Historiser les decisions de confiance.',
+      summaryStatus: 'oui',
+      businessStatus: 'oui',
+      implementationStatus: 'oui',
+      e2eStatus: 'oui',
+      priority: 'moyenne',
+      managementBucket: 'covered',
+      needsProductWorkFirst: false,
+      observedGap: 'Le flux critique est deja prouve.',
+      nextMove: 'Maintenir la regression existante.',
+      evidence: ['e2e/admin-trust-visibility.spec.ts'],
+      reviewedAt: '2026-04-07',
+    },
+  });
+}
+
+async function findMatrixEntryByEntryId(strapi, entryId) {
+  const entries = normalizeFindManyResult(
+    await strapi.entityService.findMany(MATRIX_ENTRY_UID, {
+      filters: {
+        entryId: {
+          $eq: entryId,
+        },
+      },
+      publicationState: 'preview',
+      limit: 1,
+    }),
+  );
+
+  return entries[0] ?? null;
+}
+
+async function run() {
+  applyTestEnvironment();
+  await cleanupDatabase();
+
+  const appContext = await compileStrapi();
+  const app = await createStrapi(appContext).load();
+
+  try {
+    await createMatrixEntry(app, 'trust-validation');
+
+    await app.server.listen();
+    const address = app.server.httpServer.address();
+    const port = typeof address === 'object' && address ? address.port : 1337;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const unauthorized = await requestJson(`${baseUrl}/api/admin/quality/matrix/ingest`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        mergedAt: '2026-05-02T12:00:00.000Z',
+        commitSha: 'abc123',
+        source: 'github-actions',
+        impactedEntryIds: ['trust-validation'],
+      }),
+    });
+    assert.equal(unauthorized.status, 401, 'Expected ingest without bearer token to be rejected.');
+
+    const invalidPayload = await requestJson(`${baseUrl}/api/admin/quality/matrix/ingest`, {
+      method: 'POST',
+      headers: authHeaders({ Authorization: 'Bearer matrix-ingest-test-token' }),
+      body: JSON.stringify({
+        mergedAt: '2026-05-02T12:00:00.000Z',
+        impactedEntryIds: ['trust-validation'],
+      }),
+    });
+    assert.equal(invalidPayload.status, 400, 'Expected ingest payload without commitSha to fail.');
+
+    const ok = await requestJson(`${baseUrl}/api/admin/quality/matrix/ingest`, {
+      method: 'POST',
+      headers: authHeaders({ Authorization: 'Bearer matrix-ingest-test-token' }),
+      body: JSON.stringify({
+        mergedAt: '2026-05-02T12:00:00.000Z',
+        commitSha: 'abc123def456',
+        source: 'github-actions',
+        workflow: 'Admin Quality Matrix Sync',
+        branch: 'main',
+        summary: 'targeted sync after merge to main',
+        changedFiles: ['openg7-org/src/app/domains/feed/feature/feed.page.ts'],
+        impactedEntryIds: ['trust-validation', 'unknown-entry'],
+      }),
+    });
+    assert.equal(ok.status, 200, 'Expected valid ingest request to succeed.');
+    assert.deepEqual(ok.body?.data?.updatedEntryIds, ['trust-validation']);
+    assert.deepEqual(ok.body?.data?.ignoredEntryIds, ['unknown-entry']);
+
+    const updated = await findMatrixEntryByEntryId(app, 'trust-validation');
+    assert.ok(updated, 'Expected matrix entry to still exist after ingest.');
+    assert.equal(updated.lastRepoSignalCommit, 'abc123def456');
+    assert.equal(updated.lastRepoSignalSource, 'github-actions');
+    assert.equal(updated.lastRepoSignalAt, '2026-05-02T12:00:00.000Z');
+    assert.match(updated.lastRepoSignalSummary, /targeted sync after merge to main/i);
+
+    console.log('Admin quality matrix ingest integration test passed.');
+  } finally {
+    await app.destroy();
+    await cleanupDatabase();
+  }
+}
+
+run().catch(async (error) => {
+  console.error(error);
+  await cleanupDatabase();
+  process.exit(1);
+});

--- a/strapi/scripts/test-hydrocarbon-signals-api-integration.js
+++ b/strapi/scripts/test-hydrocarbon-signals-api-integration.js
@@ -1,0 +1,257 @@
+/* eslint-disable no-console */
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { compileStrapi, createStrapi } = require('@strapi/strapi');
+
+const TEST_DB_FILENAME = `db.hydrocarbon.integration.${process.pid}.${Date.now()}.sqlite`;
+const TEST_PASSWORD = 'S3cureHydrocarbon!123';
+const HYDROCARBON_ACTIONS = [
+  'api::hydrocarbon-signal.hydrocarbon-signal.find',
+  'api::hydrocarbon-signal.hydrocarbon-signal.findOne',
+];
+
+function applyTestEnvironment() {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+  process.env.STRAPI_ENV = process.env.STRAPI_ENV || 'test';
+  process.env.STRAPI_SEED_AUTO = 'false';
+  process.env.DATABASE_CLIENT = 'sqlite';
+  process.env.DATABASE_FILENAME = TEST_DB_FILENAME;
+  process.env.HOST = '127.0.0.1';
+  process.env.PORT = '0';
+  process.env.APP_KEYS = process.env.APP_KEYS || 'hydrocarbon-test-app-key-a,hydrocarbon-test-app-key-b';
+  process.env.API_TOKEN_SALT = process.env.API_TOKEN_SALT || 'hydrocarbon-test-api-token-salt';
+  process.env.ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'hydrocarbon-test-admin-jwt-secret';
+  process.env.TRANSFER_TOKEN_SALT = process.env.TRANSFER_TOKEN_SALT || 'hydrocarbon-test-transfer-token-salt';
+  process.env.JWT_SECRET = process.env.JWT_SECRET || 'hydrocarbon-test-jwt-secret';
+  process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'hydrocarbon-test-encryption-key-1234567';
+}
+
+async function cleanupDatabase() {
+  const basePath = path.join(__dirname, '..', 'data', TEST_DB_FILENAME);
+  const candidates = [basePath, `${basePath}-wal`, `${basePath}-shm`];
+  await Promise.all(
+    candidates.map(async candidate => {
+      try {
+        await fs.rm(candidate, { force: true });
+      } catch {
+        // Ignore cleanup errors.
+      }
+    })
+  );
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = null;
+    }
+  }
+  return { response, status: response.status, body, text };
+}
+
+async function ensureRolePermissions(strapi, roleType, actions) {
+  const roleQuery = strapi.db.query('plugin::users-permissions.role');
+  const permissionQuery = strapi.db.query('plugin::users-permissions.permission');
+  const role = await roleQuery.findOne({ where: { type: roleType } });
+
+  if (!role?.id) {
+    throw new Error(`Role "${roleType}" not found.`);
+  }
+
+  for (const action of actions) {
+    const existing = await permissionQuery.findOne({ where: { role: role.id, action } });
+    if (!existing) {
+      await permissionQuery.create({ data: { role: role.id, action } });
+    }
+  }
+}
+
+async function createAuthenticatedUser(baseUrl, runId) {
+  const email = `hydrocarbon.integration.${runId}@example.test`;
+
+  const register = await requestJson(`${baseUrl}/api/auth/local/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: email,
+      email,
+      password: TEST_PASSWORD,
+    }),
+  });
+
+  assert.equal(register.status, 200, 'Expected register to succeed.');
+  assert.ok(register.body?.user?.id, 'Expected user id from register response.');
+  return register.body.user.id;
+}
+
+async function seedHydrocarbonFeed(strapi, userId, suffix, overrides = {}) {
+  const feed = await strapi.entityService.create('api::feed.feed', {
+    data: {
+      user: userId,
+      type: 'OFFER',
+      title: `Hydrocarbon Integration ${suffix}`,
+      summary: `Hydrocarbon signal ${suffix}`,
+      sectorId: 'energy',
+      fromProvinceId: 'ab',
+      toProvinceId: 'bc',
+      mode: 'EXPORT',
+      quantityValue: 48000,
+      quantityUnit: 'bbl',
+      urgency: 2,
+      credibility: 3,
+      volumeScore: 75,
+      tags: ['hydrocarbon', 'alberta', 'integration'],
+      sourceKind: 'COMPANY',
+      sourceLabel: 'Northern Prairie Energy',
+      status: 'confirmed',
+      publicationFormKey: 'hydrocarbon-surplus-offer',
+      metadata: {
+        publicationForm: {
+          formKey: 'hydrocarbon-surplus-offer',
+        },
+        extensions: {
+          companyName: 'Northern Prairie Energy',
+          publicationType: 'surplus',
+          productType: 'crudeOil',
+          businessReason: 'surplusStock',
+          volumeBarrels: 48000,
+          minimumLotBarrels: 12000,
+          availableFrom: '2026-02-01',
+          availableUntil: '2026-02-12',
+          originSite: 'Edmonton terminal cluster',
+          qualityGrade: 'wcs',
+          logisticsMode: ['rail', 'storageTransfer'],
+          targetScope: ['bc', 'refiningNetwork'],
+          storagePressureLevel: 'high',
+          priceReference: 'WCS less rail differential',
+          contactChannel: 'Crude desk - western dispatch',
+        },
+      },
+      ...overrides,
+    },
+  });
+
+  await strapi.entityService.create('api::hydrocarbon-signal.hydrocarbon-signal', {
+    data: {
+      feedItemId: String(feed.id),
+      sourceIdempotencyKey: null,
+      feedItem: feed.id,
+      owner: userId,
+      title: feed.title,
+      summary: feed.summary,
+      companyName: 'Northern Prairie Energy',
+      publicationType: feed.metadata?.extensions?.publicationType ?? 'surplus',
+      productType: feed.metadata?.extensions?.productType ?? 'crudeOil',
+      businessReason: feed.metadata?.extensions?.businessReason ?? 'surplusStock',
+      volumeBarrels: Number(feed.quantityValue),
+      quantityUnit: feed.quantityUnit,
+      minimumLotBarrels: feed.metadata?.extensions?.minimumLotBarrels ?? 12000,
+      availableFrom: feed.metadata?.extensions?.availableFrom ?? '2026-02-01',
+      availableUntil: feed.metadata?.extensions?.availableUntil ?? '2026-02-12',
+      estimatedDelayDays: feed.metadata?.extensions?.estimatedDelayDays ?? null,
+      originProvinceId: feed.fromProvinceId,
+      targetProvinceId: feed.toProvinceId,
+      originSite: feed.metadata?.extensions?.originSite ?? 'Edmonton terminal cluster',
+      qualityGrade: feed.metadata?.extensions?.qualityGrade ?? 'wcs',
+      logisticsMode: feed.metadata?.extensions?.logisticsMode ?? ['rail', 'storageTransfer'],
+      targetScope: feed.metadata?.extensions?.targetScope ?? ['bc', 'refiningNetwork'],
+      storagePressureLevel: feed.metadata?.extensions?.storagePressureLevel ?? 'high',
+      priceReference: feed.metadata?.extensions?.priceReference ?? 'WCS less rail differential',
+      responseDeadline: null,
+      contactChannel: feed.metadata?.extensions?.contactChannel ?? 'Crude desk - western dispatch',
+      notes: null,
+      tags: feed.tags,
+      sourceKind: feed.sourceKind,
+      sourceLabel: feed.sourceLabel,
+      status: 'active',
+    },
+  });
+
+  return feed;
+}
+
+async function run() {
+  applyTestEnvironment();
+  await cleanupDatabase();
+
+  const appContext = await compileStrapi();
+  const app = await createStrapi(appContext).load();
+
+  try {
+    await ensureRolePermissions(app, 'public', HYDROCARBON_ACTIONS);
+    await app.server.listen();
+
+    const address = app.server.httpServer.address();
+    const port = typeof address === 'object' && address ? address.port : 1337;
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const runId = String(Date.now());
+
+    const empty = await requestJson(`${baseUrl}/api/hydrocarbon-signals`);
+    assert.equal(empty.status, 200, 'Expected public hydrocarbon endpoint to succeed without data.');
+    assert.deepEqual(empty.body?.data, [], 'Expected no hydrocarbon signals before seeding.');
+
+    const userId = await createAuthenticatedUser(baseUrl, runId);
+    const first = await seedHydrocarbonFeed(app, userId, 'SURPLUS-A');
+    await seedHydrocarbonFeed(app, userId, 'SLOWDOWN-B', {
+      title: 'Barrel slowdown on Alberta corridor',
+      summary: 'Transport slowdown compressing dispatch capacity.',
+      toProvinceId: 'sk',
+      metadata: {
+        publicationForm: {
+          formKey: 'hydrocarbon-surplus-offer',
+        },
+        extensions: {
+          companyName: 'Northern Prairie Energy',
+          publicationType: 'slowdown',
+          productType: 'crudeOil',
+          businessReason: 'transportDisruption',
+          volumeBarrels: 36500,
+          minimumLotBarrels: 8000,
+          availableFrom: '2026-02-03',
+          availableUntil: '2026-02-09',
+          estimatedDelayDays: 6,
+          originSite: 'Hardisty routing hub',
+          qualityGrade: 'wcs',
+          logisticsMode: ['pipeline', 'storageTransfer'],
+          targetScope: ['sk', 'storageNetwork'],
+          storagePressureLevel: 'critical',
+          priceReference: 'Temporary discount against WCS',
+          contactChannel: 'Logistics coordination line',
+        },
+      },
+    });
+
+    const list = await requestJson(`${baseUrl}/api/hydrocarbon-signals?publicationType=surplus&originProvinceId=ab&limit=5`);
+    assert.equal(list.status, 200, 'Expected hydrocarbon list endpoint to succeed.');
+    assert.equal(list.body?.meta?.limit, 5, 'Expected limit to round-trip in response metadata.');
+    assert.equal(list.body?.data?.length, 1, 'Expected publicationType filter to narrow the results.');
+    assert.equal(list.body?.data?.[0]?.publicationType, 'surplus');
+    assert.equal(list.body?.data?.[0]?.quantityUnit, 'bbl');
+    assert.equal(list.body?.data?.[0]?.originProvinceId, 'ab');
+
+    const detailById = await requestJson(`${baseUrl}/api/hydrocarbon-signals/${encodeURIComponent(String(first.id))}`);
+    assert.equal(detailById.status, 200, 'Expected detail endpoint to resolve by feed item id.');
+    assert.equal(detailById.body?.data?.feedItemId, String(first.id));
+    assert.equal(detailById.body?.data?.companyName, 'Northern Prairie Energy');
+
+    const missing = await requestJson(`${baseUrl}/api/hydrocarbon-signals/999999`);
+    assert.equal(missing.status, 404, 'Expected 404 for an unknown hydrocarbon signal.');
+
+    console.log('Hydrocarbon signals integration tests passed.');
+  } finally {
+    await app.destroy();
+    await cleanupDatabase();
+  }
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/strapi/scripts/test-importation-api-integration.js
+++ b/strapi/scripts/test-importation-api-integration.js
@@ -1,0 +1,170 @@
+/* eslint-disable no-console */
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const { compileStrapi, createStrapi } = require('@strapi/strapi');
+
+const TEST_DB_FILENAME = `db.importation.integration.${process.pid}.${Date.now()}.sqlite`;
+
+function applyTestEnvironment() {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+  process.env.STRAPI_ENV = process.env.STRAPI_ENV || 'test';
+  process.env.STRAPI_SEED_AUTO = 'false';
+  process.env.DATABASE_CLIENT = 'sqlite';
+  process.env.DATABASE_FILENAME = TEST_DB_FILENAME;
+  process.env.HOST = '127.0.0.1';
+  process.env.PORT = '0';
+  process.env.APP_KEYS = process.env.APP_KEYS || 'importation-test-app-key-a,importation-test-app-key-b';
+  process.env.API_TOKEN_SALT = process.env.API_TOKEN_SALT || 'importation-test-api-token-salt';
+  process.env.ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'importation-test-admin-jwt-secret';
+  process.env.TRANSFER_TOKEN_SALT = process.env.TRANSFER_TOKEN_SALT || 'importation-test-transfer-token-salt';
+  process.env.JWT_SECRET = process.env.JWT_SECRET || 'importation-test-jwt-secret';
+  process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'importation-test-encryption-key-123456789';
+}
+
+async function cleanupDatabase() {
+  const basePath = path.join(__dirname, '..', 'data', TEST_DB_FILENAME);
+  const candidates = [basePath, `${basePath}-wal`, `${basePath}-shm`];
+  await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        await fs.rm(candidate, { force: true });
+      } catch {
+        // Ignore cleanup errors.
+      }
+    })
+  );
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = null;
+    }
+  }
+  return { response, status: response.status, body, text };
+}
+
+async function run() {
+  applyTestEnvironment();
+  await cleanupDatabase();
+
+  const appContext = await compileStrapi();
+  const app = await createStrapi(appContext).load();
+
+  try {
+    await app.server.listen();
+
+    const address = app.server.httpServer.address();
+    const port = typeof address === 'object' && address ? address.port : 1337;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    const flows = await requestJson(`${baseUrl}/api/import-flows?period=month&originScope=usmca`);
+    assert.equal(flows.status, 200, 'Expected import-flows to succeed.');
+    assert.ok(Array.isArray(flows.body?.timeline), 'Expected import-flows timeline array.');
+    assert.ok(Array.isArray(flows.body?.flows), 'Expected import-flows flows array.');
+    assert.equal(flows.body.flows[0]?.originCode, 'US', 'Expected USMCA response to be led by US data.');
+
+    const commodities = await requestJson(`${baseUrl}/api/import-commodities?period=month&originScope=g7&hsSections=85`);
+    assert.equal(commodities.status, 200, 'Expected import-commodities to succeed.');
+    assert.ok(Array.isArray(commodities.body?.top), 'Expected import-commodities top array.');
+    assert.ok(
+      commodities.body.top.every((entry) => String(entry.hsCode || '').startsWith('85')),
+      'Expected hsSections filter to constrain returned top commodities.'
+    );
+
+    const riskFlags = await requestJson(`${baseUrl}/api/import-risk-flags?originScope=g7&hsSections=85`);
+    assert.equal(riskFlags.status, 200, 'Expected import-risk-flags to succeed.');
+    assert.ok(Array.isArray(riskFlags.body), 'Expected import-risk-flags array response.');
+
+    const suppliers = await requestJson(`${baseUrl}/api/import-suppliers?originScope=indo_pacific`);
+    assert.equal(suppliers.status, 200, 'Expected import-suppliers to succeed.');
+    assert.ok(Array.isArray(suppliers.body?.suppliers), 'Expected import-suppliers list.');
+    assert.ok(
+      suppliers.body.suppliers.every((supplier) => ['JP', 'KR'].includes(supplier.originCode)),
+      'Expected indo_pacific suppliers only.'
+    );
+
+    const knowledge = await requestJson(`${baseUrl}/api/import-knowledge?lang=en`);
+    assert.equal(knowledge.status, 200, 'Expected import-knowledge to succeed.');
+    assert.equal(knowledge.body?.cta?.id, 'cta-en', 'Expected English knowledge payload.');
+
+    const annotations = await requestJson(`${baseUrl}/api/import-annotations`);
+    assert.equal(annotations.status, 200, 'Expected import-annotations to succeed.');
+    assert.ok(Array.isArray(annotations.body?.annotations), 'Expected import-annotations payload.');
+
+    const watchlistsBefore = await requestJson(`${baseUrl}/api/import-watchlists`);
+    assert.equal(watchlistsBefore.status, 200, 'Expected import-watchlists GET to succeed.');
+    const initialCount = watchlistsBefore.body?.watchlists?.length ?? 0;
+
+    const createdWatchlist = await requestJson(`${baseUrl}/api/import-watchlists`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Ontario Battery Lane',
+        filters: {
+          periodGranularity: 'month',
+          periodValue: '2026-03',
+          originScope: 'usmca',
+          originCodes: [],
+          hsSections: ['85'],
+          compareMode: false,
+          compareWith: null,
+        },
+      }),
+    });
+    assert.equal(createdWatchlist.status, 201, 'Expected watchlist creation to succeed.');
+    assert.equal(createdWatchlist.body?.name, 'Ontario Battery Lane', 'Expected created watchlist payload.');
+
+    const watchlistsAfter = await requestJson(`${baseUrl}/api/import-watchlists`);
+    assert.equal(watchlistsAfter.status, 200, 'Expected import-watchlists GET after create to succeed.');
+    assert.equal((watchlistsAfter.body?.watchlists?.length ?? 0), initialCount + 1, 'Expected created watchlist to be persisted in memory.');
+
+    const updatedWatchlist = await requestJson(`${baseUrl}/api/import-watchlists/${createdWatchlist.body?.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Ontario Battery Lane Updated',
+      }),
+    });
+    assert.equal(updatedWatchlist.status, 200, 'Expected watchlist update to succeed.');
+    assert.equal(updatedWatchlist.body?.name, 'Ontario Battery Lane Updated', 'Expected updated watchlist payload.');
+
+    const schedule = await requestJson(`${baseUrl}/api/import-reports/schedule`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        period: 'month',
+        recipients: ['ops@example.test'],
+        format: 'csv',
+        frequency: 'monthly',
+      }),
+    });
+    assert.equal(schedule.status, 202, 'Expected import report scheduling to succeed.');
+    assert.equal(schedule.body?.scheduled, true, 'Expected scheduling acknowledgement payload.');
+    assert.ok(schedule.body?.reportId, 'Expected persisted report schedule id.');
+
+    const scheduledReports = await app.entityService.findMany('api::import-report-schedule.import-report-schedule', {
+      sort: ['createdAt:desc'],
+    });
+    assert.ok(Array.isArray(scheduledReports), 'Expected persisted report schedules collection.');
+    assert.equal(scheduledReports.length, 1, 'Expected a persisted scheduled report entry.');
+    assert.deepEqual(scheduledReports[0]?.recipients, ['ops@example.test'], 'Expected recipients to be stored.');
+
+    console.log('Importation integration tests passed.');
+  } finally {
+    await app.destroy();
+    await cleanupDatabase();
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
…e-corridors-realtime components

## Summary
Describe the change (scope, motivation, user or technical impact).

## Details / decisions
- Design choices or tradeoffs
- Documentation or configuration impact

## Anti-duplication checklist
- [ ] I reviewed docs/ecosystem/ECOSYSTEM-MAP.md
- [ ] I confirmed whether this capability already has a canonical repo
- [ ] If reusable by 2+ repos, I proposed a shared @openg7/* package instead of copy/paste
- [ ] I did not introduce canonical domain logic into openg7-nexus

## Tests
- [ ] `yarn lint`
- [ ] `yarn format:check`
- [ ] `yarn validate:selectors`
- [ ] `yarn codegen && yarn test`
- [ ] `yarn predeploy:cms-cache`
- [ ] `yarn prebuild:web`
- [ ] Other (specify):

## Review
- [ ] Docs updated (README, docs, or comments)
- [ ] Screenshot attached if UI
- [ ] Linked issue referenced
