### PR TITLE
feat(opportunity-offers): add API endpoints for managing opportunity …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -756,6 +756,7 @@ Le contrat OpenAPI est versionnÃ© dans `packages/contracts/spec/openapi.json`.
 | Import annotations | `/api/import-annotations`    | â€”                                | annotations collaboratives persistÃ©es |
 | Import watchlists | `/api/import-watchlists`      | GET / POST / PUT JSON             | watchlists importation persistÃ©es |
 | Import report schedule | `/api/import-reports/schedule` | POST JSON (`period`, `recipients`, `format`, `frequency`, `notes`) | planification de rapports importation |
+| Opportunity offers | `/api/users/me/opportunity-offers` | GET / POST JSON (`opportunityId`, `capacityMw`, `startDate`, `endDate`, `pricingModel`, `comment`, `attachmentId`, `attachmentName`) | persistance des offres utilisateur sur opportunites |
 
 **Shape de rÃ©ponse (par dÃ©faut Strapi v4/v5)** :  
 ```json
@@ -1626,15 +1627,15 @@ _MAJ (enhanced) : 2026-03-14 00:00:00Z_
 - Analytics carte -> feed corridor (`map_open_corridor_feed`) : `corridorId`, `sector`, `fromProvince`, `toProvince`, `mode`, `priority`, `decisionItemId`, `cmsKey`, `input`, `sourceRoute`, `targetRoute`.
 - Analytics endpoint (si configure) : `event`, `detail`, `priority`, `timestamp`.
 - Notification webhook/email (si active) : `notification.id`, `notification.type`, `notification.title`, `notification.message`, `notification.source`, `notification.createdAt`, `notification.metadata`, `recipient`.
+- `POST /api/users/me/opportunity-offers` : `opportunityId`, `opportunityTitle`, `opportunityRoute`, `feedItemId`, `recipientKind`, `recipientLabel`, `capacityMw`, `startDate`, `endDate`, `pricingModel`, `comment`, `attachmentId`, `attachmentName`, `submittedAt`, `correlationId`, `idempotencyKey`.
 - Events UI locaux (non persistes backend) :
-- `OpportunityOfferPayload` : `capacityMw`, `startDate`, `endDate`, `pricingModel`, `comment`, `attachmentName`.
+- `OpportunityOfferPayload` : `capacityMw`, `startDate`, `endDate`, `pricingModel`, `comment`, `attachmentName` (miroir UI, persiste via `/api/users/me/opportunity-offers`).
 - `IndicatorAlertDraft` : `thresholdDirection`, `thresholdValue`, `window`, `frequency`, `notifyDelta`, `note`.
 - Q/R opportunite : `content` (soumis localement).
 
 ### TO-BE - Proprietes a ajouter pour couvrir totalement mission + blueprints
 
-- Persister la soumission d offre opportunite :
-- `opportunityId`, `capacityMw`, `startDate`, `endDate`, `pricingModel`, `comment`, `attachmentId`, `attachmentName`, `submittedAt`.
+- Completer la piece jointe binaire des offres opportunite : `attachmentId`, stockage fichier et scan securite.
 - Durcir la persistance de creation d alerte indicateur (au-dela du mapping `POST /api/feed`) :
 - `indicatorId`, `thresholdDirection`, `thresholdValue`, `window`, `frequency`, `notifyDelta`, `note`, `createdAt`, `deliveryChannels`.
 - Persister les actions header/detail aujourd hui locales :

--- a/openg7-org/src/app/core/api/strapi.routes.ts
+++ b/openg7-org/src/app/core/api/strapi.routes.ts
@@ -16,6 +16,7 @@ export const STRAPI_ROUTES = {
     meProfileLogoutOthers: '/api/users/me/profile/sessions/logout-others',
     meProfileEmailChange: '/api/users/me/profile/email-change',
     meFavorites: '/api/users/me/favorites',
+    meOpportunityOffers: '/api/users/me/opportunity-offers',
     meSavedSearches: '/api/users/me/saved-searches',
     meAlerts: '/api/users/me/alerts',
   },

--- a/openg7-org/src/app/core/opportunity-offers.service.spec.ts
+++ b/openg7-org/src/app/core/opportunity-offers.service.spec.ts
@@ -1,11 +1,13 @@
 import { PLATFORM_ID, computed, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { AuthService } from './auth/auth.service';
 import {
   CreateOpportunityOfferPayload,
   OpportunityOffersService,
 } from './opportunity-offers.service';
+import { OpportunityOffersApiService } from './services/opportunity-offers-api.service';
 
 describe('OpportunityOffersService', () => {
   let authState: ReturnType<typeof signal<boolean>>;
@@ -17,6 +19,7 @@ describe('OpportunityOffersService', () => {
       lastName: string;
     } | null>
   >;
+  let offersApi: jasmine.SpyObj<OpportunityOffersApiService>;
 
   const createService = () => TestBed.inject(OpportunityOffersService);
 
@@ -30,10 +33,15 @@ describe('OpportunityOffersService', () => {
     } | null>(null);
 
     clearOpportunityOfferStorage();
+    offersApi = jasmine.createSpyObj<OpportunityOffersApiService>('OpportunityOffersApiService', [
+      'createMine',
+      'listMine',
+    ]);
 
     TestBed.configureTestingModule({
       providers: [
         OpportunityOffersService,
+        { provide: OpportunityOffersApiService, useValue: offersApi },
         {
           provide: AuthService,
           useValue: {
@@ -72,6 +80,64 @@ describe('OpportunityOffersService', () => {
     expect(service.entries().length).toBe(1);
     expect(service.entries()[0]?.opportunityTitle).toBe('Short-term import of 300 MW');
     expect(service.entries()[0]?.senderEmail).toBe('user-1@openg7.test');
+  });
+
+  it('persists submitted offers remotely and mirrors the server record locally', async () => {
+    authState.set(true);
+    userState.set({
+      id: 'user-1',
+      email: 'user-1@openg7.test',
+      firstName: 'Open',
+      lastName: 'G7',
+    });
+    offersApi.createMine.and.returnValue(
+      of({
+        ...createPayload(),
+        id: 'remote-offer-1',
+        reference: 'OG7-OFR-20260115-REMOTE',
+        opportunityRoute: '/feed/opportunities/request-001',
+        feedItemId: 'feed-offer-1',
+        recipientKind: 'PARTNER',
+        senderUserId: 'user-1',
+        senderLabel: 'Open G7',
+        senderEmail: 'user-1@openg7.test',
+        attachmentId: null,
+        attachmentName: 'term-sheet.pdf',
+        status: 'submitted',
+        allocatedCapacityMw: null,
+        remainingOpportunityCapacityMw: null,
+        createdAt: '2026-01-15T10:00:00.000Z',
+        updatedAt: '2026-01-15T10:00:00.000Z',
+        submittedAt: '2026-01-15T10:00:00.000Z',
+        withdrawnAt: null,
+        activities: [],
+        correlationId: 'corr-1',
+        idempotencyKey: 'idem-1',
+      }),
+    );
+
+    const service = createService();
+    const record = await service.submit(createPayload(), {
+      feedItemId: 'feed-offer-1',
+      idempotencyKey: 'idem-1',
+      correlationId: 'corr-1',
+    });
+
+    expect(offersApi.createMine).toHaveBeenCalledWith(
+      {
+        ...createPayload(),
+        feedItemId: 'feed-offer-1',
+        attachmentId: null,
+        correlationId: 'corr-1',
+      },
+      {
+        idempotencyKey: 'idem-1',
+        suppressErrorToast: true,
+      },
+    );
+    expect(record.id).toBe('remote-offer-1');
+    expect(service.entries()[0]?.id).toBe('remote-offer-1');
+    expect(service.entries()[0]?.feedItemId).toBe('feed-offer-1');
   });
 
   it('keeps offers partitioned by user id', () => {
@@ -155,7 +221,7 @@ describe('OpportunityOffersService', () => {
 });
 
 function createPayload(
-  patch: Partial<CreateOpportunityOfferPayload> = {}
+  patch: Partial<CreateOpportunityOfferPayload> = {},
 ): CreateOpportunityOfferPayload {
   return {
     opportunityId: 'request-001',

--- a/openg7-org/src/app/core/opportunity-offers.service.ts
+++ b/openg7-org/src/app/core/opportunity-offers.service.ts
@@ -1,6 +1,8 @@
-import { Injectable, PLATFORM_ID, computed, inject } from '@angular/core';
+import { Injectable, Injector, PLATFORM_ID, computed, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 
 import { AuthService } from './auth/auth.service';
+import { OpportunityOffersApiService } from './services/opportunity-offers-api.service';
 import { createUserScopedPersistentState } from './storage/user-scoped-persistent-state';
 
 const STORAGE_KEY_PREFIX = 'og7.opportunity-offers.v1';
@@ -29,6 +31,7 @@ export interface OpportunityOfferRecord {
   opportunityId: string;
   opportunityTitle: string;
   opportunityRoute: string | null;
+  feedItemId?: string | null;
   recipientKind: OpportunityOfferRecipientKind;
   recipientLabel: string;
   senderUserId: string;
@@ -39,6 +42,7 @@ export interface OpportunityOfferRecord {
   endDate: string;
   pricingModel: string;
   comment: string;
+  attachmentId?: string | null;
   attachmentName: string | null;
   status: OpportunityOfferStatus;
   allocatedCapacityMw: number | null;
@@ -48,6 +52,8 @@ export interface OpportunityOfferRecord {
   submittedAt: string;
   withdrawnAt: string | null;
   activities: readonly OpportunityOfferActivityRecord[];
+  correlationId?: string | null;
+  idempotencyKey?: string | null;
 }
 
 export interface CreateOpportunityOfferPayload {
@@ -64,9 +70,17 @@ export interface CreateOpportunityOfferPayload {
   attachmentName?: string | null;
 }
 
+export interface PersistOpportunityOfferOptions {
+  feedItemId?: string | null;
+  attachmentId?: string | null;
+  correlationId?: string | null;
+  idempotencyKey?: string | null;
+}
+
 @Injectable({ providedIn: 'root' })
 export class OpportunityOffersService {
   private readonly auth = inject(AuthService);
+  private readonly injector = inject(Injector);
   private readonly state = createUserScopedPersistentState<OpportunityOfferRecord[]>({
     auth: this.auth,
     platformId: inject(PLATFORM_ID),
@@ -82,7 +96,9 @@ export class OpportunityOffersService {
     this.state.refresh();
   }
 
-  entriesForOpportunity(opportunityId: string | null | undefined): readonly OpportunityOfferRecord[] {
+  entriesForOpportunity(
+    opportunityId: string | null | undefined,
+  ): readonly OpportunityOfferRecord[] {
     const normalizedId = this.normalizeId(opportunityId);
     if (!normalizedId) {
       return [];
@@ -123,8 +139,40 @@ export class OpportunityOffersService {
     const nextEntries = this.sortEntries([record, ...this.entries()]);
     this.state.setForCurrentUser(
       nextEntries,
-      'Opportunity offers require an authenticated session.'
+      'Opportunity offers require an authenticated session.',
     );
+    return record;
+  }
+
+  async submit(
+    payload: CreateOpportunityOfferPayload,
+    options: PersistOpportunityOfferOptions = {},
+  ): Promise<OpportunityOfferRecord> {
+    this.currentUserOrThrow();
+    const api = this.resolveApiService();
+    if (!api) {
+      return this.create(payload);
+    }
+
+    const operationKey = options.correlationId?.trim() || this.generateId();
+    const idempotencyKey = options.idempotencyKey?.trim() || operationKey;
+    const record = this.normalizeRecord(
+      await firstValueFrom(
+        api.createMine(
+          {
+            ...payload,
+            feedItemId: options.feedItemId ?? null,
+            attachmentId: options.attachmentId ?? null,
+            correlationId: operationKey,
+          },
+          {
+            idempotencyKey,
+            suppressErrorToast: true,
+          },
+        ),
+      ),
+    );
+    this.upsertRecord(record);
     return record;
   }
 
@@ -154,7 +202,7 @@ export class OpportunityOffersService {
               type: 'qualified',
               actor: 'system',
               createdAt: now,
-            })
+            }),
           );
         }
         newActivities.push(
@@ -162,7 +210,7 @@ export class OpportunityOffersService {
             type: 'inDiscussion',
             actor: 'system',
             createdAt: now,
-          })
+          }),
         );
 
         updatedRecord = {
@@ -172,19 +220,19 @@ export class OpportunityOffersService {
           activities: this.sortActivities([...newActivities, ...entry.activities]),
         };
         return updatedRecord;
-      })
+      }),
     );
 
     this.state.setForCurrentUser(
       nextEntries,
-      'Opportunity offers require an authenticated session.'
+      'Opportunity offers require an authenticated session.',
     );
     return updatedRecord;
   }
 
   markPartiallyServed(
     id: string,
-    allocation: { allocatedCapacityMw: number; remainingOpportunityCapacityMw: number | null }
+    allocation: { allocatedCapacityMw: number; remainingOpportunityCapacityMw: number | null },
   ): OpportunityOfferRecord | null {
     const normalizedId = this.normalizeId(id);
     if (!normalizedId) {
@@ -193,14 +241,18 @@ export class OpportunityOffersService {
 
     const allocatedCapacityMw = this.normalizeNumber(allocation.allocatedCapacityMw);
     const remainingOpportunityCapacityMw = this.normalizeNullableNumber(
-      allocation.remainingOpportunityCapacityMw
+      allocation.remainingOpportunityCapacityMw,
     );
 
     let updatedRecord: OpportunityOfferRecord | null = null;
     const now = new Date().toISOString();
     const nextEntries = this.sortEntries(
       this.entries().map((entry) => {
-        if (entry.id !== normalizedId || entry.status === 'withdrawn' || entry.status === 'partiallyServed') {
+        if (
+          entry.id !== normalizedId ||
+          entry.status === 'withdrawn' ||
+          entry.status === 'partiallyServed'
+        ) {
           return entry;
         }
 
@@ -211,7 +263,7 @@ export class OpportunityOffersService {
               type: 'qualified',
               actor: 'system',
               createdAt: now,
-            })
+            }),
           );
         }
         if (!entry.activities.some((activity) => activity.type === 'inDiscussion')) {
@@ -220,7 +272,7 @@ export class OpportunityOffersService {
               type: 'inDiscussion',
               actor: 'system',
               createdAt: now,
-            })
+            }),
           );
         }
         newActivities.push(
@@ -228,7 +280,7 @@ export class OpportunityOffersService {
             type: 'partiallyServed',
             actor: 'system',
             createdAt: now,
-          })
+          }),
         );
 
         updatedRecord = {
@@ -240,12 +292,12 @@ export class OpportunityOffersService {
           activities: this.sortActivities([...newActivities, ...entry.activities]),
         };
         return updatedRecord;
-      })
+      }),
     );
 
     this.state.setForCurrentUser(
       nextEntries,
-      'Opportunity offers require an authenticated session.'
+      'Opportunity offers require an authenticated session.',
     );
     return updatedRecord;
   }
@@ -278,19 +330,19 @@ export class OpportunityOffersService {
           ]),
         };
         return updatedRecord;
-      })
+      }),
     );
 
     this.state.setForCurrentUser(
       nextEntries,
-      'Opportunity offers require an authenticated session.'
+      'Opportunity offers require an authenticated session.',
     );
     return updatedRecord;
   }
 
   private currentUserOrThrow(): { id: string; email: string; label: string } {
     const userId = this.state.requireCurrentUserId(
-      'Opportunity offers require an authenticated session.'
+      'Opportunity offers require an authenticated session.',
     );
     const profile = this.auth.user();
     const email = this.normalizeText(profile?.email, 'unknown@openg7.local');
@@ -314,9 +366,7 @@ export class OpportunityOffersService {
 
   private normalizeRecord(candidate: unknown): OpportunityOfferRecord {
     const record =
-      candidate && typeof candidate === 'object'
-        ? (candidate as Record<string, unknown>)
-        : {};
+      candidate && typeof candidate === 'object' ? (candidate as Record<string, unknown>) : {};
     const now = new Date().toISOString();
     const createdAt = this.normalizeIsoTimestamp(record['createdAt']) ?? now;
     const updatedAt = this.normalizeIsoTimestamp(record['updatedAt']) ?? createdAt;
@@ -337,6 +387,7 @@ export class OpportunityOffersService {
       opportunityId: this.normalizeId(record['opportunityId']) ?? 'opportunity',
       opportunityTitle: this.normalizeText(record['opportunityTitle'], 'Opportunity'),
       opportunityRoute: this.normalizeRoute(record['opportunityRoute']),
+      feedItemId: this.normalizeNullableText(record['feedItemId']),
       recipientKind: this.normalizeRecipientKind(record['recipientKind']),
       recipientLabel: this.normalizeText(record['recipientLabel'], 'Unknown recipient'),
       senderUserId: this.normalizeId(record['senderUserId']) ?? 'user',
@@ -347,16 +398,42 @@ export class OpportunityOffersService {
       endDate: this.normalizeText(record['endDate'], ''),
       pricingModel: this.normalizeText(record['pricingModel'], 'spot'),
       comment: this.normalizeText(record['comment'], ''),
+      attachmentId: this.normalizeNullableText(record['attachmentId']),
       attachmentName: this.normalizeNullableText(record['attachmentName']),
       status,
       allocatedCapacityMw: this.normalizeNullableNumber(record['allocatedCapacityMw']),
-      remainingOpportunityCapacityMw: this.normalizeNullableNumber(record['remainingOpportunityCapacityMw']),
+      remainingOpportunityCapacityMw: this.normalizeNullableNumber(
+        record['remainingOpportunityCapacityMw'],
+      ),
       createdAt,
       updatedAt: this.maxTimestamp(updatedAt, activities[0]?.createdAt ?? null),
       submittedAt,
       withdrawnAt,
       activities,
+      correlationId: this.normalizeNullableText(record['correlationId']),
+      idempotencyKey: this.normalizeNullableText(record['idempotencyKey']),
     };
+  }
+
+  private upsertRecord(record: OpportunityOfferRecord): void {
+    const nextEntries = this.sortEntries([
+      record,
+      ...this.entries().filter(
+        (entry) => entry.id !== record.id && entry.reference !== record.reference,
+      ),
+    ]);
+    this.state.setForCurrentUser(
+      nextEntries,
+      'Opportunity offers require an authenticated session.',
+    );
+  }
+
+  private resolveApiService(): OpportunityOffersApiService | null {
+    try {
+      return this.injector.get(OpportunityOffersApiService);
+    } catch {
+      return null;
+    }
   }
 
   private sortEntries(entries: readonly OpportunityOfferRecord[]): OpportunityOfferRecord[] {
@@ -389,13 +466,13 @@ export class OpportunityOffersService {
       submittedAt: string;
       withdrawnAt: string | null;
       status: OpportunityOfferStatus;
-    }
+    },
   ): OpportunityOfferActivityRecord[] {
     if (Array.isArray(candidate)) {
       const normalized = this.sortActivities(
         candidate
           .map((entry) => this.normalizeActivity(entry))
-          .filter((entry): entry is OpportunityOfferActivityRecord => Boolean(entry))
+          .filter((entry): entry is OpportunityOfferActivityRecord => Boolean(entry)),
       );
       if (normalized.length > 0) {
         return normalized;
@@ -426,7 +503,7 @@ export class OpportunityOffersService {
           type: 'inDiscussion',
           actor: 'system',
           createdAt: fallback.createdAt,
-        })
+        }),
       );
     }
 
@@ -436,7 +513,7 @@ export class OpportunityOffersService {
           type: 'partiallyServed',
           actor: 'system',
           createdAt: fallback.createdAt,
-        })
+        }),
       );
     }
 
@@ -446,7 +523,7 @@ export class OpportunityOffersService {
           type: 'withdrawn',
           actor: 'sender',
           createdAt: fallback.withdrawnAt,
-        })
+        }),
       );
     }
 
@@ -455,9 +532,7 @@ export class OpportunityOffersService {
 
   private normalizeActivity(candidate: unknown): OpportunityOfferActivityRecord | null {
     const activity =
-      candidate && typeof candidate === 'object'
-        ? (candidate as Record<string, unknown>)
-        : {};
+      candidate && typeof candidate === 'object' ? (candidate as Record<string, unknown>) : {};
     const createdAt = this.normalizeIsoTimestamp(activity['createdAt']);
     if (!createdAt) {
       return null;
@@ -502,7 +577,9 @@ export class OpportunityOffersService {
     };
   }
 
-  private sortActivities(entries: readonly OpportunityOfferActivityRecord[]): OpportunityOfferActivityRecord[] {
+  private sortActivities(
+    entries: readonly OpportunityOfferActivityRecord[],
+  ): OpportunityOfferActivityRecord[] {
     return [...entries].sort((left, right) => {
       const timestampOrder = this.toTimestamp(right.createdAt) - this.toTimestamp(left.createdAt);
       if (timestampOrder !== 0) {

--- a/openg7-org/src/app/core/services/opportunity-offers-api.service.spec.ts
+++ b/openg7-org/src/app/core/services/opportunity-offers-api.service.spec.ts
@@ -1,0 +1,77 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { API_URL, API_WITH_CREDENTIALS } from '../config/environment.tokens';
+
+import { OpportunityOffersApiService } from './opportunity-offers-api.service';
+
+describe('OpportunityOffersApiService', () => {
+  let service: OpportunityOffersApiService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: API_URL, useValue: 'https://api.openg7.test' },
+        { provide: API_WITH_CREDENTIALS, useValue: false },
+      ],
+    });
+
+    service = TestBed.inject(OpportunityOffersApiService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('posts opportunity offers with an idempotency key', () => {
+    const payload = {
+      opportunityId: 'request-001',
+      opportunityTitle: 'Short-term import of 300 MW',
+      opportunityRoute: '/feed/opportunities/request-001',
+      feedItemId: 'feed-offer-1',
+      recipientKind: 'PARTNER' as const,
+      recipientLabel: 'Hydro Desk',
+      capacityMw: 320,
+      startDate: '2026-01-15',
+      endDate: '2026-02-15',
+      pricingModel: 'spot',
+      comment: 'Firm import block for winter peak support.',
+      attachmentName: 'term-sheet.pdf',
+      correlationId: 'operation-1',
+    };
+
+    service.createMine(payload, { idempotencyKey: 'operation-1:record' }).subscribe((record) => {
+      expect(record.reference).toBe('OG7-OFR-20260115-AB12');
+    });
+
+    const request = http.expectOne('https://api.openg7.test/api/users/me/opportunity-offers');
+    expect(request.request.method).toBe('POST');
+    expect(request.request.headers.get('Idempotency-Key')).toBe('operation-1:record');
+    expect(request.request.body).toEqual(payload);
+
+    request.flush({
+      data: {
+        id: 'offer-record-1',
+        reference: 'OG7-OFR-20260115-AB12',
+        ...payload,
+        attachmentId: null,
+        senderUserId: 'user-1',
+        senderLabel: 'Open G7',
+        senderEmail: 'user-1@openg7.test',
+        status: 'submitted',
+        allocatedCapacityMw: null,
+        remainingOpportunityCapacityMw: null,
+        createdAt: '2026-01-15T10:00:00.000Z',
+        updatedAt: '2026-01-15T10:00:00.000Z',
+        submittedAt: '2026-01-15T10:00:00.000Z',
+        withdrawnAt: null,
+        activities: [],
+      },
+    });
+  });
+});

--- a/openg7-org/src/app/core/services/opportunity-offers-api.service.ts
+++ b/openg7-org/src/app/core/services/opportunity-offers-api.service.ts
@@ -1,0 +1,64 @@
+import { HttpContext, HttpHeaders } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { STRAPI_ROUTES } from '@app/core/api/strapi.routes';
+import { SUPPRESS_ERROR_TOAST } from '@app/core/http/error.interceptor.tokens';
+import { HttpClientService } from '@app/core/http/http-client.service';
+import { map, Observable } from 'rxjs';
+
+import type {
+  CreateOpportunityOfferPayload,
+  OpportunityOfferRecord,
+} from '../opportunity-offers.service';
+
+export interface PersistOpportunityOfferPayload extends CreateOpportunityOfferPayload {
+  feedItemId?: string | null;
+  attachmentId?: string | null;
+  correlationId?: string | null;
+}
+
+export interface PersistOpportunityOfferOptions {
+  idempotencyKey?: string | null;
+  suppressErrorToast?: boolean;
+}
+
+interface OpportunityOfferRecordResponse {
+  data: OpportunityOfferRecord;
+}
+
+interface OpportunityOfferCollectionResponse {
+  data: OpportunityOfferRecord[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class OpportunityOffersApiService {
+  private readonly http = inject(HttpClientService);
+
+  listMine(opportunityId?: string | null): Observable<OpportunityOfferRecord[]> {
+    const params = opportunityId ? { opportunityId } : undefined;
+    return this.http
+      .get<OpportunityOfferCollectionResponse>(STRAPI_ROUTES.users.meOpportunityOffers, {
+        params,
+        context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true),
+      })
+      .pipe(map((response) => response.data));
+  }
+
+  createMine(
+    payload: PersistOpportunityOfferPayload,
+    options: PersistOpportunityOfferOptions = {},
+  ): Observable<OpportunityOfferRecord> {
+    return this.http
+      .post<OpportunityOfferRecordResponse>(STRAPI_ROUTES.users.meOpportunityOffers, payload, {
+        headers: this.createHeaders(options),
+        context: options.suppressErrorToast
+          ? new HttpContext().set(SUPPRESS_ERROR_TOAST, true)
+          : undefined,
+      })
+      .pipe(map((response) => response.data));
+  }
+
+  private createHeaders(options: PersistOpportunityOfferOptions): HttpHeaders | undefined {
+    const idempotencyKey = options.idempotencyKey?.trim();
+    return idempotencyKey ? new HttpHeaders({ 'Idempotency-Key': idempotencyKey }) : undefined;
+  }
+}

--- a/openg7-org/src/app/domains/feed/feature/feed-offer-submission.helpers.ts
+++ b/openg7-org/src/app/domains/feed/feature/feed-offer-submission.helpers.ts
@@ -22,7 +22,7 @@ export function buildOpportunityOfferDraft(
   source: OpportunityOfferDraftSource,
   payload: OpportunityOfferPayload,
   sectorFallback: string | null,
-  translate: Pick<TranslateService, 'instant'>
+  translate: Pick<TranslateService, 'instant'>,
 ): FeedComposerDraft {
   const titlePrefix = translate.instant('feed.opportunity.detail.offer.generatedTitlePrefix');
   const title = `${titlePrefix}: ${source.title}`.slice(0, 160);
@@ -57,7 +57,7 @@ export function buildOpportunityOfferDraft(
 export function buildOpportunityOfferRecordPayload(
   source: OpportunityOfferRecordSource,
   route: string,
-  payload: OpportunityOfferPayload
+  payload: OpportunityOfferPayload,
 ): CreateOpportunityOfferPayload {
   return {
     opportunityId: source.id,
@@ -76,7 +76,7 @@ export function buildOpportunityOfferRecordPayload(
 
 export function resolveOpportunityOfferSubmitErrorMessage(
   outcome: FeedPublishOutcome,
-  translate: Pick<TranslateService, 'instant'>
+  translate: Pick<TranslateService, 'instant'>,
 ): string | null {
   if (outcome.status === 'success') {
     return null;
@@ -92,4 +92,19 @@ export function resolveOpportunityOfferSubmitErrorMessage(
   }
 
   return outcome.error ?? translate.instant('feed.error.generic');
+}
+
+export function createOpportunityOfferOperationKey(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) {
+    return `opportunity-offer-${uuid}`;
+  }
+  return `opportunity-offer-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function buildOpportunityOfferIdempotencyKey(
+  operationKey: string,
+  step: 'feed' | 'record',
+): string {
+  return `${operationKey}:${step}`.slice(0, 140);
 }

--- a/openg7-org/src/app/domains/feed/feature/feed.page.spec.ts
+++ b/openg7-org/src/app/domains/feed/feature/feed.page.spec.ts
@@ -174,6 +174,9 @@ class OpportunityOffersServiceMock {
     status: 'submitted',
     ...payload,
   }));
+  readonly submit = jasmine
+    .createSpy('submit')
+    .and.callFake(async (payload) => this.create(payload));
   readonly withdraw = jasmine.createSpy('withdraw');
 }
 
@@ -860,19 +863,26 @@ describe('FeedPage', () => {
     expect(publishedDraft.fromProvinceId).toBe('qc');
     expect(publishedDraft.toProvinceId).toBe('on');
     expect(publishedDraft.quantity).toEqual({ value: 340, unit: 'MW' });
-    expect(opportunityOffers.create).toHaveBeenCalledWith({
-      opportunityId: 'opportunity-300mw',
-      opportunityTitle: 'Item opportunity-300mw',
-      opportunityRoute: '/feed',
-      recipientKind: 'PARTNER',
-      recipientLabel: 'Grid Ops',
-      capacityMw: 340,
-      startDate: '2026-01-20',
-      endDate: '2026-02-18',
-      pricingModel: 'spot',
-      comment: 'Firm import block for winter peak support.',
-      attachmentName: 'term-sheet.pdf',
-    });
+    expect(opportunityOffers.submit).toHaveBeenCalledWith(
+      {
+        opportunityId: 'opportunity-300mw',
+        opportunityTitle: 'Item opportunity-300mw',
+        opportunityRoute: '/feed',
+        recipientKind: 'PARTNER',
+        recipientLabel: 'Grid Ops',
+        capacityMw: 340,
+        startDate: '2026-01-20',
+        endDate: '2026-02-18',
+        pricingModel: 'spot',
+        comment: 'Firm import block for winter peak support.',
+        attachmentName: 'term-sheet.pdf',
+      },
+      jasmine.objectContaining({
+        feedItemId: null,
+        correlationId: jasmine.any(String),
+        idempotencyKey: jasmine.stringMatching(/:record$/),
+      }),
+    );
     expect(notifications.success).toHaveBeenCalledWith(
       'feed.opportunity.detail.offer.status.successReference',
       {
@@ -880,8 +890,10 @@ describe('FeedPage', () => {
         metadata: {
           action: 'create-opportunity-offer',
           itemId: 'opportunity-300mw',
+          feedItemId: null,
           offerId: 'offer-record-1',
           offerReference: 'OG7-OFR-20260120-AB12',
+          correlationId: jasmine.any(String),
         },
       },
     );
@@ -919,7 +931,7 @@ describe('FeedPage', () => {
 
     expect(component.contactSubmitState()).toBe('error');
     expect(component.contactSubmitError()).toBe('feed.error.generic');
-    expect(opportunityOffers.create).not.toHaveBeenCalled();
+    expect(opportunityOffers.submit).not.toHaveBeenCalled();
     expect(notifications.error).toHaveBeenCalledWith('feed.error.generic', {
       source: 'feed',
       metadata: {

--- a/openg7-org/src/app/domains/feed/feature/feed.page.ts
+++ b/openg7-org/src/app/domains/feed/feature/feed.page.ts
@@ -16,7 +16,10 @@ import { resolveCorridorContext } from '@app/core/config/corridor-context';
 import { FavoritesService } from '@app/core/favorites.service';
 import { AnalyticsService } from '@app/core/observability/analytics.service';
 import { injectNotificationStore } from '@app/core/observability/notification.store';
-import { OpportunityOffersService } from '@app/core/opportunity-offers.service';
+import {
+  OpportunityOffersService,
+  type OpportunityOfferRecord,
+} from '@app/core/opportunity-offers.service';
 import {
   feedCategorySig,
   feedFormKeySig,
@@ -38,8 +41,10 @@ import {
 import { OpportunityOfferDrawerComponent } from './components/opportunity-offer-drawer.component';
 import { buildFeedFavoriteKey, isFeedOpportunityType } from './feed-item.helpers';
 import {
+  buildOpportunityOfferIdempotencyKey,
   buildOpportunityOfferDraft,
   buildOpportunityOfferRecordPayload,
+  createOpportunityOfferOperationKey,
   resolveOpportunityOfferSubmitErrorMessage,
 } from './feed-offer-submission.helpers';
 import { FeedPublishSectionComponent } from './feed-publish-section/feed-publish-section.component';
@@ -85,6 +90,7 @@ export class FeedPage {
     initialValue: this.route.snapshot.data,
   });
   private pendingContactPayload: OpportunityOfferPayload | null = null;
+  private pendingContactOperationKey: string | null = null;
   private contactStatusTimer: ReturnType<typeof setTimeout> | null = null;
 
   readonly items = this.feed.items;
@@ -321,6 +327,7 @@ export class FeedPage {
 
   handleContactSubmitted(payload: OpportunityOfferPayload): void {
     this.pendingContactPayload = payload;
+    this.pendingContactOperationKey = createOpportunityOfferOperationKey();
     void this.submitContactPayload(payload);
   }
 
@@ -371,6 +378,8 @@ export class FeedPage {
     }
 
     this.contactSubmitState.set('submitting');
+    const operationKey = this.pendingContactOperationKey ?? createOpportunityOfferOperationKey();
+    this.pendingContactOperationKey = operationKey;
     const outcome = await this.feed.publishDraft(
       buildOpportunityOfferDraft(
         item,
@@ -378,6 +387,9 @@ export class FeedPage {
         this.items().find((entry) => entry.sectorId)?.sectorId ?? null,
         this.translate,
       ),
+      {
+        idempotencyKey: buildOpportunityOfferIdempotencyKey(operationKey, 'feed'),
+      },
     );
     const errorMessage = resolveOpportunityOfferSubmitErrorMessage(outcome, this.translate);
 
@@ -394,12 +406,36 @@ export class FeedPage {
       return;
     }
 
-    const record = this.opportunityOffers.create(
-      buildOpportunityOfferRecordPayload(item, this.currentInternalUrl(), payload),
-    );
+    let record: OpportunityOfferRecord;
+    try {
+      record = await this.opportunityOffers.submit(
+        buildOpportunityOfferRecordPayload(item, this.currentInternalUrl(), payload),
+        {
+          feedItemId: outcome.item?.id ?? null,
+          idempotencyKey: buildOpportunityOfferIdempotencyKey(operationKey, 'record'),
+          correlationId: operationKey,
+        },
+      );
+    } catch (error) {
+      const message = this.translate.instant('feed.opportunity.detail.offer.status.errorGeneric');
+      this.contactSubmitState.set('error');
+      this.contactSubmitError.set(message);
+      this.notifications.error(message, {
+        source: 'feed',
+        context: error,
+        metadata: {
+          action: 'create-opportunity-offer',
+          itemId: item.id,
+          feedItemId: outcome.item?.id ?? null,
+          correlationId: operationKey,
+        },
+      });
+      return;
+    }
     this.contactSubmitState.set('success');
     this.contactSubmitError.set(null);
     this.pendingContactPayload = null;
+    this.pendingContactOperationKey = null;
     this.notifications.success(
       this.translate.instant('feed.opportunity.detail.offer.status.successReference', {
         reference: record.reference,
@@ -409,8 +445,10 @@ export class FeedPage {
         metadata: {
           action: 'create-opportunity-offer',
           itemId: item.id,
+          feedItemId: outcome.item?.id ?? null,
           offerId: record.id,
           offerReference: record.reference,
+          correlationId: operationKey,
         },
       },
     );
@@ -429,6 +467,7 @@ export class FeedPage {
   private resetContactSubmitState(): void {
     this.clearContactStatusTimer();
     this.pendingContactPayload = null;
+    this.pendingContactOperationKey = null;
     this.contactSubmitState.set('idle');
     this.contactSubmitError.set(null);
   }

--- a/openg7-org/src/app/domains/feed/feature/models/feed.models.ts
+++ b/openg7-org/src/app/domains/feed/feature/models/feed.models.ts
@@ -1,12 +1,6 @@
 import { Signal } from '@angular/core';
 
-export type FeedItemType =
-  | 'OFFER'
-  | 'REQUEST'
-  | 'ALERT'
-  | 'TENDER'
-  | 'CAPACITY'
-  | 'INDICATOR';
+export type FeedItemType = 'OFFER' | 'REQUEST' | 'ALERT' | 'TENDER' | 'CAPACITY' | 'INDICATOR';
 
 export type FeedItemCategory = 'OPPORTUNITY' | 'ALERT' | 'INDICATOR';
 
@@ -125,6 +119,7 @@ export interface FeedPublishOutcome {
 
 export interface FeedPublishOptions {
   readonly metadata?: FeedPublicationMetadata | null;
+  readonly idempotencyKey?: string | null;
 }
 
 export interface FeedRealtimeConnectionState {

--- a/openg7-org/src/app/domains/feed/feature/pages/feed-opportunity-detail.page.spec.ts
+++ b/openg7-org/src/app/domains/feed/feature/pages/feed-opportunity-detail.page.spec.ts
@@ -50,9 +50,7 @@ class StoreMock {
     { id: 'on', name: 'Ontario' },
     { id: 'qc', name: 'Quebec' },
   ]);
-  private readonly sectorsSig = signal([
-    { id: 'energy', name: 'Energy' },
-  ]);
+  private readonly sectorsSig = signal([{ id: 'energy', name: 'Energy' }]);
   private selectCallCount = 0;
 
   readonly selectSignal = jasmine.createSpy('selectSignal').and.callFake(() => {
@@ -70,10 +68,10 @@ class FavoritesServiceMock {
   readonly list = this.listSig.asReadonly();
   readonly refresh = jasmine.createSpy('refresh');
   readonly add = jasmine.createSpy('add').and.callFake((item: string) => {
-    this.listSig.update(current => (current.includes(item) ? current : [...current, item]));
+    this.listSig.update((current) => (current.includes(item) ? current : [...current, item]));
   });
   readonly remove = jasmine.createSpy('remove').and.callFake((item: string) => {
-    this.listSig.update(current => current.filter(entry => entry !== item));
+    this.listSig.update((current) => current.filter((entry) => entry !== item));
   });
 
   setItems(items: string[]): void {
@@ -117,14 +115,25 @@ class OpportunityReportQueueServiceMock {
       comment: string;
       createdAt: string;
       status: 'pending';
-    } | null
+    } | null,
   ): void {
     this.pendingReport = record;
   }
 }
 
 class OpportunityConversationDraftsServiceMock {
-  private readonly entriesSig = signal<Record<string, readonly { id: string; tab: 'questions' | 'offers' | 'history'; author: string; content: string; createdAt: string }[]>>({});
+  private readonly entriesSig = signal<
+    Record<
+      string,
+      readonly {
+        id: string;
+        tab: 'questions' | 'offers' | 'history';
+        author: string;
+        content: string;
+        createdAt: string;
+      }[]
+    >
+  >({});
 
   messagesFor(itemId: string | null | undefined) {
     if (!itemId) {
@@ -133,15 +142,33 @@ class OpportunityConversationDraftsServiceMock {
     return this.entriesSig()[itemId] ?? [];
   }
 
-  append(itemId: string, message: { id: string; tab: 'questions' | 'offers' | 'history'; author: string; content: string; createdAt: string }) {
-    this.entriesSig.update(current => ({
+  append(
+    itemId: string,
+    message: {
+      id: string;
+      tab: 'questions' | 'offers' | 'history';
+      author: string;
+      content: string;
+      createdAt: string;
+    },
+  ) {
+    this.entriesSig.update((current) => ({
       ...current,
       [itemId]: [message, ...(current[itemId] ?? [])],
     }));
   }
 
-  setMessages(itemId: string, messages: readonly { id: string; tab: 'questions' | 'offers' | 'history'; author: string; content: string; createdAt: string }[]) {
-    this.entriesSig.update(current => ({
+  setMessages(
+    itemId: string,
+    messages: readonly {
+      id: string;
+      tab: 'questions' | 'offers' | 'history';
+      author: string;
+      content: string;
+      createdAt: string;
+    }[],
+  ) {
+    this.entriesSig.update((current) => ({
       ...current,
       [itemId]: messages,
     }));
@@ -155,61 +182,68 @@ class OpportunityOffersServiceMock {
 
   readonly refresh = jasmine.createSpy('refresh');
   readonly withdraw = jasmine.createSpy('withdraw');
-  readonly create = jasmine.createSpy('create').and.callFake((payload: {
-    opportunityId: string;
-    opportunityTitle: string;
-    opportunityRoute?: string | null;
-    recipientKind: 'GOV' | 'COMPANY' | 'PARTNER' | 'USER';
-    recipientLabel: string;
-    capacityMw: number;
-    startDate: string;
-    endDate: string;
-    pricingModel: string;
-    comment: string;
-    attachmentName?: string | null;
-  }) => {
-    const record: OpportunityOfferRecord = {
-      id: 'offer-record-1',
-      reference: 'OG7-OFR-20260115-AB12',
-      opportunityId: payload.opportunityId,
-      opportunityTitle: payload.opportunityTitle,
-      opportunityRoute: payload.opportunityRoute ?? null,
-      recipientKind: payload.recipientKind,
-      recipientLabel: payload.recipientLabel,
-      senderUserId: 'user-1',
-      senderLabel: 'E2E User',
-      senderEmail: 'e2e.user@openg7.test',
-      capacityMw: payload.capacityMw,
-      startDate: payload.startDate,
-      endDate: payload.endDate,
-      pricingModel: payload.pricingModel,
-      comment: payload.comment,
-      attachmentName: payload.attachmentName ?? null,
-      status: 'submitted',
-      allocatedCapacityMw: null,
-      remainingOpportunityCapacityMw: null,
-      createdAt: '2026-01-15T10:06:00.000Z',
-      updatedAt: '2026-01-15T10:06:00.000Z',
-      submittedAt: '2026-01-15T10:06:00.000Z',
-      withdrawnAt: null,
-      activities: [
-        {
-          id: 'offer-activity-track-1',
-          type: 'tracked',
-          actor: 'system',
+  readonly create = jasmine
+    .createSpy('create')
+    .and.callFake(
+      (payload: {
+        opportunityId: string;
+        opportunityTitle: string;
+        opportunityRoute?: string | null;
+        recipientKind: 'GOV' | 'COMPANY' | 'PARTNER' | 'USER';
+        recipientLabel: string;
+        capacityMw: number;
+        startDate: string;
+        endDate: string;
+        pricingModel: string;
+        comment: string;
+        attachmentName?: string | null;
+      }) => {
+        const record: OpportunityOfferRecord = {
+          id: 'offer-record-1',
+          reference: 'OG7-OFR-20260115-AB12',
+          opportunityId: payload.opportunityId,
+          opportunityTitle: payload.opportunityTitle,
+          opportunityRoute: payload.opportunityRoute ?? null,
+          recipientKind: payload.recipientKind,
+          recipientLabel: payload.recipientLabel,
+          senderUserId: 'user-1',
+          senderLabel: 'E2E User',
+          senderEmail: 'e2e.user@openg7.test',
+          capacityMw: payload.capacityMw,
+          startDate: payload.startDate,
+          endDate: payload.endDate,
+          pricingModel: payload.pricingModel,
+          comment: payload.comment,
+          attachmentName: payload.attachmentName ?? null,
+          status: 'submitted',
+          allocatedCapacityMw: null,
+          remainingOpportunityCapacityMw: null,
           createdAt: '2026-01-15T10:06:00.000Z',
-        },
-        {
-          id: 'offer-activity-submit-1',
-          type: 'submitted',
-          actor: 'sender',
-          createdAt: '2026-01-15T10:06:00.000Z',
-        },
-      ],
-    };
-    this.entriesSig.update((current) => [record, ...current]);
-    return record;
-  });
+          updatedAt: '2026-01-15T10:06:00.000Z',
+          submittedAt: '2026-01-15T10:06:00.000Z',
+          withdrawnAt: null,
+          activities: [
+            {
+              id: 'offer-activity-track-1',
+              type: 'tracked',
+              actor: 'system',
+              createdAt: '2026-01-15T10:06:00.000Z',
+            },
+            {
+              id: 'offer-activity-submit-1',
+              type: 'submitted',
+              actor: 'sender',
+              createdAt: '2026-01-15T10:06:00.000Z',
+            },
+          ],
+        };
+        this.entriesSig.update((current) => [record, ...current]);
+        return record;
+      },
+    );
+  readonly submit = jasmine
+    .createSpy('submit')
+    .and.callFake(async (payload) => this.create(payload));
 
   entriesForOpportunity(itemId: string | null | undefined): readonly OpportunityOfferRecord[] {
     if (!itemId) {
@@ -281,21 +315,26 @@ describe('FeedOpportunityDetailPage', () => {
     });
 
     routeParamMap$ = new BehaviorSubject(convertToParamMap({ itemId: 'opportunity-300mw' }));
-    queryParamMap$ = new BehaviorSubject(convertToParamMap({
-      source: 'corridors-realtime',
-      corridorId: 'essential-services',
-    }));
+    queryParamMap$ = new BehaviorSubject(
+      convertToParamMap({
+        source: 'corridors-realtime',
+        corridorId: 'essential-services',
+      }),
+    );
     const routeStub: Pick<ActivatedRoute, 'paramMap' | 'queryParamMap' | 'snapshot'> = {
       paramMap: routeParamMap$.asObservable(),
       queryParamMap: queryParamMap$.asObservable(),
       get snapshot() {
-        const queryParams = queryParamMap$.value.keys.reduce<Record<string, string>>((params, key) => {
-          const value = queryParamMap$.value.get(key);
-          if (typeof value === 'string') {
-            params[key] = value;
-          }
-          return params;
-        }, {});
+        const queryParams = queryParamMap$.value.keys.reduce<Record<string, string>>(
+          (params, key) => {
+            const value = queryParamMap$.value.get(key);
+            if (typeof value === 'string') {
+              params[key] = value;
+            }
+            return params;
+          },
+          {},
+        );
         return {
           paramMap: routeParamMap$.value,
           queryParamMap: queryParamMap$.value,
@@ -368,30 +407,42 @@ describe('FeedOpportunityDetailPage', () => {
     expect(publishedDraft.fromProvinceId).toBe('qc');
     expect(publishedDraft.toProvinceId).toBe('on');
     expect(publishedDraft.quantity).toEqual({ value: 320, unit: 'MW' });
-    expect(opportunityOffers.create).toHaveBeenCalledTimes(1);
-    expect(opportunityOffers.create).toHaveBeenCalledWith({
-      opportunityId: 'opportunity-300mw',
-      opportunityTitle: 'Short-term import of 300 MW',
-      opportunityRoute: '/feed/opportunities/opportunity-300mw',
-      recipientKind: 'PARTNER',
-      recipientLabel: 'Hydro Desk',
-      capacityMw: 320,
-      startDate: '2026-01-15',
-      endDate: '2026-02-15',
-      pricingModel: 'spot',
-      comment: 'Firm import block for winter peak support.',
-      attachmentName: 'term-sheet.pdf',
-    });
-    expect(component.offerSubmitState()).toBe('success');
-    expect(notifications.success).toHaveBeenCalledWith('feed.opportunity.detail.offer.status.successReference', {
-      source: 'feed',
-      metadata: {
-        action: 'create-opportunity-offer',
-        itemId: 'opportunity-300mw',
-        offerId: 'offer-record-1',
-        offerReference: 'OG7-OFR-20260115-AB12',
+    expect(opportunityOffers.submit).toHaveBeenCalledTimes(1);
+    expect(opportunityOffers.submit).toHaveBeenCalledWith(
+      {
+        opportunityId: 'opportunity-300mw',
+        opportunityTitle: 'Short-term import of 300 MW',
+        opportunityRoute: '/feed/opportunities/opportunity-300mw',
+        recipientKind: 'PARTNER',
+        recipientLabel: 'Hydro Desk',
+        capacityMw: 320,
+        startDate: '2026-01-15',
+        endDate: '2026-02-15',
+        pricingModel: 'spot',
+        comment: 'Firm import block for winter peak support.',
+        attachmentName: 'term-sheet.pdf',
       },
-    });
+      jasmine.objectContaining({
+        feedItemId: null,
+        correlationId: jasmine.any(String),
+        idempotencyKey: jasmine.stringMatching(/:record$/),
+      }),
+    );
+    expect(component.offerSubmitState()).toBe('success');
+    expect(notifications.success).toHaveBeenCalledWith(
+      'feed.opportunity.detail.offer.status.successReference',
+      {
+        source: 'feed',
+        metadata: {
+          action: 'create-opportunity-offer',
+          itemId: 'opportunity-300mw',
+          feedItemId: null,
+          offerId: 'offer-record-1',
+          offerReference: 'OG7-OFR-20260115-AB12',
+          correlationId: jasmine.any(String),
+        },
+      },
+    );
   });
 
   it('exposes trade-map context when a pinned corridor query is preserved into the detail page', async () => {
@@ -456,7 +507,7 @@ describe('FeedOpportunityDetailPage', () => {
 
     expect(component.offerSubmitState()).toBe('error');
     expect(component.offerSubmitError()).toBe('feed.error.generic');
-    expect(opportunityOffers.create).not.toHaveBeenCalled();
+    expect(opportunityOffers.submit).not.toHaveBeenCalled();
     expect(notifications.error).toHaveBeenCalledWith('feed.error.generic', {
       source: 'feed',
       metadata: {
@@ -640,7 +691,9 @@ describe('FeedOpportunityDetailPage', () => {
     component.handleQnaSubmit('Need validation from grid operator');
     fixture.detectChanges();
 
-    const newMessage = component.qnaMessages().find(message => message.content === 'Need validation from grid operator');
+    const newMessage = component
+      .qnaMessages()
+      .find((message) => message.content === 'Need validation from grid operator');
     expect(newMessage?.tab).toBe('history');
   });
 
@@ -663,7 +716,9 @@ describe('FeedOpportunityDetailPage', () => {
       qnaMessages: () => readonly { content: string }[];
     };
 
-    expect(component.qnaMessages().some(message => message.content === 'Persisted local follow-up')).toBeTrue();
+    expect(
+      component.qnaMessages().some((message) => message.content === 'Persisted local follow-up'),
+    ).toBeTrue();
   });
 
   it('surfaces persisted tracked offers inside the offers tab conversation stream', async () => {
@@ -689,7 +744,9 @@ describe('FeedOpportunityDetailPage', () => {
       qnaMessages: () => readonly { tab: 'questions' | 'offers' | 'history'; content: string }[];
     };
 
-    expect(component.qnaMessages().some((message) => message.content.includes('OG7-OFR-20260115-AB12'))).toBeTrue();
+    expect(
+      component.qnaMessages().some((message) => message.content.includes('OG7-OFR-20260115-AB12')),
+    ).toBeTrue();
   });
 
   it('exposes linked alerts with stable ids that resolve to real alert detail routes', async () => {
@@ -701,7 +758,10 @@ describe('FeedOpportunityDetailPage', () => {
       detailVm: () => { alerts: readonly { id: string }[] } | null;
     };
 
-    expect(component.detailVm()?.alerts.map(alert => alert.id)).toEqual(['alert-001', 'alert-002']);
+    expect(component.detailVm()?.alerts.map((alert) => alert.id)).toEqual([
+      'alert-001',
+      'alert-002',
+    ]);
   });
 
   it('navigates to alert detail when opening a related alert from context aside', async () => {
@@ -920,13 +980,16 @@ describe('FeedOpportunityDetailPage real template', () => {
       paramMap: routeParamMap$.asObservable(),
       queryParamMap: queryParamMap$.asObservable(),
       get snapshot() {
-        const queryParams = queryParamMap$.value.keys.reduce<Record<string, string>>((params, key) => {
-          const value = queryParamMap$.value.get(key);
-          if (typeof value === 'string') {
-            params[key] = value;
-          }
-          return params;
-        }, {});
+        const queryParams = queryParamMap$.value.keys.reduce<Record<string, string>>(
+          (params, key) => {
+            const value = queryParamMap$.value.get(key);
+            if (typeof value === 'string') {
+              params[key] = value;
+            }
+            return params;
+          },
+          {},
+        );
         return {
           paramMap: routeParamMap$.value,
           queryParamMap: queryParamMap$.value,
@@ -1000,8 +1063,12 @@ describe('FeedOpportunityDetailPage real template', () => {
     fixture.detectChanges();
 
     const content = fixture.nativeElement.textContent;
-    expect(fixture.nativeElement.querySelector('[data-og7="opportunity-detail-page"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-og7="publication-metadata-card"]')).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-og7="opportunity-detail-page"]'),
+    ).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-og7="publication-metadata-card"]'),
+    ).toBeTruthy();
     expect(content).toContain('feed.publicationMetadata.title');
     expect(content).toContain('forms.energySurplus.title');
     expect(content).toContain('hydroelectric');
@@ -1011,7 +1078,8 @@ describe('FeedOpportunityDetailPage real template', () => {
     routeParamMap$.next(convertToParamMap({ itemId: 'hydrocarbon-opportunity-001' }));
     const item = createOpportunityItem('hydrocarbon-opportunity-001', {
       title: '48 000 barils disponibles apres ralentissement de corridor',
-      summary: 'Northern Prairie Energy cherche des acheteurs ou stockeurs pour absorber un surplus temporaire.',
+      summary:
+        'Northern Prairie Energy cherche des acheteurs ou stockeurs pour absorber un surplus temporaire.',
       fromProvinceId: 'ab',
       toProvinceId: 'bc',
       mode: 'EXPORT',
@@ -1049,7 +1117,9 @@ describe('FeedOpportunityDetailPage real template', () => {
 
     const content = fixture.nativeElement.textContent;
     expect(content).toContain('feed.opportunity.detail.hydrocarbon.title');
-    expect(fixture.nativeElement.querySelector('[data-og7="hydrocarbon-detail-card"]')).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-og7="hydrocarbon-detail-card"]'),
+    ).toBeTruthy();
     expect(content).toContain('feed.opportunity.detail.hydrocarbon.window');
     expect(content).toContain('forms.hydrocarbonSurplus.fields.publicationType.options.slowdown');
     expect(content).toContain('forms.hydrocarbonSurplus.fields.qualityGrade.options.wcs');

--- a/openg7-org/src/app/domains/feed/feature/pages/feed-opportunity-detail.page.ts
+++ b/openg7-org/src/app/domains/feed/feature/pages/feed-opportunity-detail.page.ts
@@ -37,8 +37,10 @@ import { OpportunityOfferDrawerComponent } from '../components/opportunity-offer
 import { OpportunityReportDrawerComponent } from '../components/opportunity-report-drawer.component';
 import { isFeedOpportunityType } from '../feed-item.helpers';
 import {
+  buildOpportunityOfferIdempotencyKey,
   buildOpportunityOfferDraft,
   buildOpportunityOfferRecordPayload,
+  createOpportunityOfferOperationKey,
   resolveOpportunityOfferSubmitErrorMessage,
 } from '../feed-offer-submission.helpers';
 import { FeedItem } from '../models/feed.models';
@@ -78,6 +80,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
 
   private readonly syncTimers: ReturnType<typeof setTimeout>[] = [];
   private pendingOfferPayload: OpportunityOfferPayload | null = null;
+  private pendingOfferOperationKey: string | null = null;
   private offerStatusTimer: ReturnType<typeof setTimeout> | null = null;
   private reportStatusTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -130,11 +133,15 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
   protected readonly existingSubmittedOffer = computed(() => {
     const detail = this.detailVm();
     const itemId = detail?.item.id ?? this.itemId();
-    return this.opportunityOffers
-      .entriesForOpportunity(itemId)
-      .find((entry) => entry.status !== 'withdrawn') ?? null;
+    return (
+      this.opportunityOffers
+        .entriesForOpportunity(itemId)
+        .find((entry) => entry.status !== 'withdrawn') ?? null
+    );
   });
-  protected readonly hasExistingSubmittedOffer = computed(() => this.existingSubmittedOffer() !== null);
+  protected readonly hasExistingSubmittedOffer = computed(
+    () => this.existingSubmittedOffer() !== null,
+  );
   protected readonly pendingReport = computed(() => {
     const detail = this.detailVm();
     if (!detail) {
@@ -324,7 +331,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
     }
 
     const sectorLabel = detail?.item.sectorId
-      ? this.resolveSectorLabel(detail.item.sectorId)?.trim().toLowerCase() ?? null
+      ? (this.resolveSectorLabel(detail.item.sectorId)?.trim().toLowerCase() ?? null)
       : null;
     if (detail?.item.sectorId && sectorLabel && normalized === sectorLabel) {
       queryParams['sector'] = detail.item.sectorId;
@@ -386,6 +393,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
 
   protected handleOfferSubmitted(payload: OpportunityOfferPayload): void {
     this.pendingOfferPayload = payload;
+    this.pendingOfferOperationKey = createOpportunityOfferOperationKey();
     void this.submitOfferPayload(payload);
   }
 
@@ -406,14 +414,17 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
       this.reportSubmitState.set('success');
       this.reportSubmitError.set(null);
       this.syncState.set('saved-local');
-      this.notifications.success(this.translate.instant('feed.opportunity.detail.report.status.success'), {
-        source: 'feed',
-        metadata: {
-          itemId: detail.item.id,
-          reportId: record.id,
-          reason: payload.reason,
+      this.notifications.success(
+        this.translate.instant('feed.opportunity.detail.report.status.success'),
+        {
+          source: 'feed',
+          metadata: {
+            itemId: detail.item.id,
+            reportId: record.id,
+            reason: payload.reason,
+          },
         },
-      });
+      );
       this.closeReportDrawerAfterSuccess();
     } catch (error) {
       const message = this.resolveLoadError(error);
@@ -459,7 +470,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
 
   private openExistingOffer(
     offer: OpportunityOfferRecord,
-    navigation = this.opportunityEngagement.buildExistingOfferNavigation(offer.id)
+    navigation = this.opportunityEngagement.buildExistingOfferNavigation(offer.id),
   ): void {
     this.notifications.info(
       this.translate.instant('feed.opportunity.detail.offer.status.existingOfferRedirect', {
@@ -473,7 +484,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
           offerReference: offer.reference,
           route: 'alerts',
         },
-      }
+      },
     );
     void this.router.navigate(navigation.commands, navigation.extras);
   }
@@ -499,6 +510,8 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
     }
 
     this.offerSubmitState.set('submitting');
+    const operationKey = this.pendingOfferOperationKey ?? createOpportunityOfferOperationKey();
+    this.pendingOfferOperationKey = operationKey;
     const outcome = await this.feed.publishDraft(
       buildOpportunityOfferDraft(
         {
@@ -511,8 +524,11 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
         },
         payload,
         this.sectors()[0]?.id ?? null,
-        this.translate
-      )
+        this.translate,
+      ),
+      {
+        idempotencyKey: buildOpportunityOfferIdempotencyKey(operationKey, 'feed'),
+      },
     );
     const errorMessage = resolveOpportunityOfferSubmitErrorMessage(outcome, this.translate);
 
@@ -529,26 +545,50 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
       return;
     }
 
-    const record = this.opportunityOffers.create(
-      buildOpportunityOfferRecordPayload(
+    let record: OpportunityOfferRecord;
+    try {
+      record = await this.opportunityOffers.submit(
+        buildOpportunityOfferRecordPayload(
+          {
+            id: detail.item.id,
+            title: detail.title,
+            sectorId: detail.item.sectorId,
+            fromProvinceId: detail.item.fromProvinceId,
+            toProvinceId: detail.item.toProvinceId,
+            mode: detail.item.mode,
+            tags: detail.item.tags,
+            source: detail.item.source,
+          },
+          this.currentInternalUrl(),
+          payload,
+        ),
         {
-          id: detail.item.id,
-          title: detail.title,
-          sectorId: detail.item.sectorId,
-          fromProvinceId: detail.item.fromProvinceId,
-          toProvinceId: detail.item.toProvinceId,
-          mode: detail.item.mode,
-          tags: detail.item.tags,
-          source: detail.item.source,
+          feedItemId: outcome.item?.id ?? null,
+          idempotencyKey: buildOpportunityOfferIdempotencyKey(operationKey, 'record'),
+          correlationId: operationKey,
         },
-        this.currentInternalUrl(),
-        payload
-      )
-    );
+      );
+    } catch (error) {
+      const message = this.translate.instant('feed.opportunity.detail.offer.status.errorGeneric');
+      this.offerSubmitState.set('error');
+      this.offerSubmitError.set(message);
+      this.notifications.error(message, {
+        source: 'feed',
+        context: error,
+        metadata: {
+          action: 'create-opportunity-offer',
+          itemId: detail.item.id,
+          feedItemId: outcome.item?.id ?? null,
+          correlationId: operationKey,
+        },
+      });
+      return;
+    }
     this.qnaTab.set('offers');
     this.offerSubmitState.set('success');
     this.offerSubmitError.set(null);
     this.pendingOfferPayload = null;
+    this.pendingOfferOperationKey = null;
     this.simulateSync();
     this.notifications.success(
       this.translate.instant('feed.opportunity.detail.offer.status.successReference', {
@@ -559,10 +599,12 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
         metadata: {
           action: 'create-opportunity-offer',
           itemId: detail.item.id,
+          feedItemId: outcome.item?.id ?? null,
           offerId: record.id,
           offerReference: record.reference,
+          correlationId: operationKey,
         },
-      }
+      },
     );
     this.closeOfferDrawerAfterSuccess();
   }
@@ -610,6 +652,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
   private resetOfferSubmitState(): void {
     this.clearOfferStatusTimer();
     this.pendingOfferPayload = null;
+    this.pendingOfferOperationKey = null;
     this.offerSubmitState.set('idle');
     this.offerSubmitError.set(null);
   }
@@ -639,16 +682,19 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
   private buildDetailVm(item: FeedItem): OpportunityDetailVm {
     const fromLabel = this.resolveProvinceLabel(item.fromProvinceId) ?? 'Quebec';
     const toLabel = this.resolveProvinceLabel(item.toProvinceId) ?? 'Ontario';
-    const sectorLabel = this.resolveSectorLabel(item.sectorId) ?? this.translate.instant('feed.opportunity.detail.energy');
+    const sectorLabel =
+      this.resolveSectorLabel(item.sectorId) ??
+      this.translate.instant('feed.opportunity.detail.energy');
     const routeLabel = `${fromLabel} -> ${toLabel}`;
     const capacityMw =
       item.quantity && item.quantity.unit === 'MW' && Number.isFinite(item.quantity.value)
         ? Math.round(item.quantity.value)
         : 300;
 
-    const visibilityLabel = item.source.kind === 'PARTNER'
-      ? this.translate.instant('feed.opportunity.detail.visibilityNetwork')
-      : this.translate.instant('feed.opportunity.detail.visibilityPublic');
+    const visibilityLabel =
+      item.source.kind === 'PARTNER'
+        ? this.translate.instant('feed.opportunity.detail.visibilityNetwork')
+        : this.translate.instant('feed.opportunity.detail.visibilityPublic');
 
     const urgencyLabel =
       (item.urgency ?? 0) >= 3
@@ -856,7 +902,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
   private toTitleCase(value: string): string {
     return value
       .split(/\s+/)
-      .map(part => part.slice(0, 1).toUpperCase() + part.slice(1).toLowerCase())
+      .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1).toLowerCase())
       .join(' ');
   }
 
@@ -871,7 +917,7 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
     this.syncState.set('saved-local');
     this.syncTimers.push(
       setTimeout(() => this.syncState.set('syncing'), 260),
-      setTimeout(() => this.syncState.set('synced'), 950)
+      setTimeout(() => this.syncState.set('synced'), 950),
     );
   }
 
@@ -895,19 +941,21 @@ export class FeedOpportunityDetailPage extends FeedDetailPageBase {
   private redirectToLogin(): void {
     const navigation = this.opportunityEngagement.buildLoginNavigation(
       this.currentInternalUrl(`/feed/opportunities/${this.itemId() ?? 'unknown'}`),
-      `/feed/opportunities/${this.itemId() ?? 'unknown'}`
+      `/feed/opportunities/${this.itemId() ?? 'unknown'}`,
     );
     void this.router.navigate(navigation.commands, navigation.extras);
   }
 
-  private currentInternalUrl(fallback = `/feed/opportunities/${this.itemId() ?? 'unknown'}`): string {
+  private currentInternalUrl(
+    fallback = `/feed/opportunities/${this.itemId() ?? 'unknown'}`,
+  ): string {
     const navigation = this.router.getCurrentNavigation();
-    const url = navigation?.finalUrl?.toString() ?? navigation?.extractedUrl?.toString() ?? this.router.url;
+    const url =
+      navigation?.finalUrl?.toString() ?? navigation?.extractedUrl?.toString() ?? this.router.url;
     return this.opportunityEngagement.normalizeInternalUrl(url, fallback);
   }
 
   protected override isExpectedItem(item: FeedItem | null): item is FeedItem {
     return isFeedOpportunityType(item?.type ?? null);
   }
-
 }

--- a/openg7-org/src/app/domains/feed/feature/services/feed-realtime.service.ts
+++ b/openg7-org/src/app/domains/feed/feature/services/feed-realtime.service.ts
@@ -108,7 +108,7 @@ export class FeedRealtimeService {
   private readonly analytics = inject(AnalyticsService);
   private readonly opportunityArchive = inject(OpportunityArchiveService);
   private readonly useMockFeed = Boolean(
-    this.featureFlags?.['feedMocks'] ?? this.featureFlags?.['homeFeedMocks']
+    this.featureFlags?.['feedMocks'] ?? this.featureFlags?.['homeFeedMocks'],
   );
 
   private eventSource: EventSource | null = null;
@@ -134,7 +134,9 @@ export class FeedRealtimeService {
   private readonly stateSig = this.store.selectSignal(selectFeedState);
   private readonly onboardingSeenSig = this.store.selectSignal(selectFeedOnboardingSeen);
 
-  readonly items = computed(() => this.itemsSig().map(item => this.opportunityArchive.apply(item)));
+  readonly items = computed(() =>
+    this.itemsSig().map((item) => this.opportunityArchive.apply(item)),
+  );
   readonly loading = this.loadingSig;
   readonly error = this.errorSig;
   readonly onboardingSeen = this.onboardingSeenSig;
@@ -155,48 +157,42 @@ export class FeedRealtimeService {
     }
 
     if (!this.browser) {
-      effect(
-        () => {
-          const snapshot = toFeedSnapshot(this.stateSig());
-          this.transferState.set(TRANSFER_STATE_KEY, snapshot);
-        }
-      );
+      effect(() => {
+        const snapshot = toFeedSnapshot(this.stateSig());
+        this.transferState.set(TRANSFER_STATE_KEY, snapshot);
+      });
     }
 
-    effect(
-      () => {
-        const filters = this.filtersSig();
-        this.updateSignalIfChanged(fromProvinceIdSig, filters.fromProvinceId);
-        this.updateSignalIfChanged(toProvinceIdSig, filters.toProvinceId);
-        this.updateSignalIfChanged(sectorIdSig, filters.sectorId);
-        this.updateSignalIfChanged(feedFormKeySig, filters.formKey);
-        this.updateSignalIfChanged(feedCategorySig, filters.category);
-        this.updateSignalIfChanged(feedTypeSig, filters.type);
-        this.updateSignalIfChanged(feedModeSig, filters.mode);
-        this.updateSignalIfChanged(feedSearchSig, filters.search);
-        this.updateSignalIfChanged(feedSortSig, filters.sort);
-      }
-    );
+    effect(() => {
+      const filters = this.filtersSig();
+      this.updateSignalIfChanged(fromProvinceIdSig, filters.fromProvinceId);
+      this.updateSignalIfChanged(toProvinceIdSig, filters.toProvinceId);
+      this.updateSignalIfChanged(sectorIdSig, filters.sectorId);
+      this.updateSignalIfChanged(feedFormKeySig, filters.formKey);
+      this.updateSignalIfChanged(feedCategorySig, filters.category);
+      this.updateSignalIfChanged(feedTypeSig, filters.type);
+      this.updateSignalIfChanged(feedModeSig, filters.mode);
+      this.updateSignalIfChanged(feedSearchSig, filters.search);
+      this.updateSignalIfChanged(feedSortSig, filters.sort);
+    });
 
-    effect(
-      () => {
-        const filters: FeedFilterState = {
-          fromProvinceId: fromProvinceIdSig(),
-          toProvinceId: toProvinceIdSig(),
-          sectorId: sectorIdSig(),
-          formKey: feedFormKeySig(),
-          category: feedCategorySig(),
-          type: feedTypeSig(),
-          mode: feedModeSig(),
-          sort: feedSortSig(),
-          search: feedSearchSig(),
-        };
-        const current = this.filtersSig();
-        if (!this.equalFilters(current, filters)) {
-          this.store.dispatch(FeedActions.applyFilters({ filters }));
-        }
+    effect(() => {
+      const filters: FeedFilterState = {
+        fromProvinceId: fromProvinceIdSig(),
+        toProvinceId: toProvinceIdSig(),
+        sectorId: sectorIdSig(),
+        formKey: feedFormKeySig(),
+        category: feedCategorySig(),
+        type: feedTypeSig(),
+        mode: feedModeSig(),
+        sort: feedSortSig(),
+        search: feedSearchSig(),
+      };
+      const current = this.filtersSig();
+      if (!this.equalFilters(current, filters)) {
+        this.store.dispatch(FeedActions.applyFilters({ filters }));
       }
-    );
+    });
 
     effect(() => {
       const hydrated = this.hydratedSig();
@@ -212,18 +208,18 @@ export class FeedRealtimeService {
       this.fetchPage({ replace: true });
     });
 
-    effect(
-      () => {
-        const itemId = this.drawerSig();
-        if (focusItemIdSig() !== itemId) {
-          focusItemIdSig.set(itemId);
-        }
+    effect(() => {
+      const itemId = this.drawerSig();
+      if (focusItemIdSig() !== itemId) {
+        focusItemIdSig.set(itemId);
       }
-    );
+    });
 
     if (this.browser) {
       if (this.useMockFeed) {
-        this.store.dispatch(FeedActions.setConnectionStatus({ connected: true, reconnecting: false }));
+        this.store.dispatch(
+          FeedActions.setConnectionStatus({ connected: true, reconnecting: false }),
+        );
         this.store.dispatch(FeedActions.setConnectionError({ error: null }));
       } else {
         this.connect();
@@ -268,7 +264,7 @@ export class FeedRealtimeService {
       return null;
     }
 
-    const existing = this.items().find(item => item.id === normalizedId);
+    const existing = this.items().find((item) => item.id === normalizedId);
     if (existing) {
       return this.normalizeItem(existing);
     }
@@ -282,7 +278,9 @@ export class FeedRealtimeService {
     const context = createSilentHttpContext();
 
     try {
-      const response = await firstValueFrom(this.http.get<ItemResponse | FeedItem>(url, { context }));
+      const response = await firstValueFrom(
+        this.http.get<ItemResponse | FeedItem>(url, { context }),
+      );
       return this.normalizeItemResponse(response);
     } catch (error) {
       const status = error instanceof HttpErrorResponse ? error.status : null;
@@ -364,7 +362,7 @@ export class FeedRealtimeService {
       return validation;
     }
 
-    void this.commitPublish(context).catch(error => {
+    void this.commitPublish(context).catch((error) => {
       const message = this.extractError(error);
       this.handlePublishFailure({
         tempId: context.optimisticItem.id,
@@ -376,7 +374,10 @@ export class FeedRealtimeService {
     return validation;
   }
 
-  async publishDraft(draft: FeedComposerDraft, options?: FeedPublishOptions): Promise<FeedPublishOutcome> {
+  async publishDraft(
+    draft: FeedComposerDraft,
+    options?: FeedPublishOptions,
+  ): Promise<FeedPublishOutcome> {
     const { validation, context } = this.startPublish(draft, options);
     if (!context) {
       return {
@@ -415,11 +416,15 @@ export class FeedRealtimeService {
     this.scheduleReconnect(0);
   }
 
-  private createPublishContext(draft: FeedComposerDraft, options?: FeedPublishOptions): PublishContext {
+  private createPublishContext(
+    draft: FeedComposerDraft,
+    options?: FeedPublishOptions,
+  ): PublishContext {
     this.markOnboardingSeen();
     const normalizedDraft = this.normalizeDraft(draft);
     const metadata = this.normalizePublicationMetadata(options?.metadata);
-    const idempotencyKey = this.generateIdempotencyKey();
+    const idempotencyKey =
+      this.normalizeIdempotencyKey(options?.idempotencyKey) ?? this.generateIdempotencyKey();
     const optimisticItem = this.buildOptimisticItem(normalizedDraft, idempotencyKey, metadata);
     return {
       normalizedDraft,
@@ -441,7 +446,7 @@ export class FeedRealtimeService {
         draft: context.normalizedDraft,
         item: context.optimisticItem,
         idempotencyKey: context.idempotencyKey,
-      })
+      }),
     );
     this.emitAnalytics('feed.item.publish.started', this.buildPublishAnalyticsPayload(context));
 
@@ -464,10 +469,14 @@ export class FeedRealtimeService {
     }
 
     const response = await firstValueFrom(
-      this.http.post<ItemResponse | FeedItem>(this.composeUrl(COLLECTION_ENDPOINT), this.createPublishRequestBody(context), {
-        headers: this.createPublishHeaders(context),
-        context: createSilentHttpContext(),
-      })
+      this.http.post<ItemResponse | FeedItem>(
+        this.composeUrl(COLLECTION_ENDPOINT),
+        this.createPublishRequestBody(context),
+        {
+          headers: this.createPublishHeaders(context),
+          context: createSilentHttpContext(),
+        },
+      ),
     );
     const item = this.normalizeItemResponse(response);
     this.handlePublishSuccess({
@@ -482,7 +491,7 @@ export class FeedRealtimeService {
   }
 
   private createPublishRequestBody(
-    context: PublishContext
+    context: PublishContext,
   ): FeedComposerDraft & { metadata?: FeedPublicationMetadata | null } {
     return {
       ...context.normalizedDraft,
@@ -501,7 +510,7 @@ export class FeedRealtimeService {
 
   private cacheMockItem(item: FeedItem): void {
     const existing = this.mockFeedCache ?? [];
-    const withoutDuplicate = existing.filter(entry => entry.id !== item.id);
+    const withoutDuplicate = existing.filter((entry) => entry.id !== item.id);
     this.mockFeedCache = [item, ...withoutDuplicate];
   }
 
@@ -540,15 +549,22 @@ export class FeedRealtimeService {
       ...this.buildPublishAnalyticsPayload(publishContext),
       reason: error,
     });
-    this.notifications.error(this.translate.instant('feed.notifications.publishFailure', { reason: error }), {
-      source: 'feed',
-      context,
-      metadata: { reason: error },
-      deliver: { email: true },
-    });
+    this.notifications.error(
+      this.translate.instant('feed.notifications.publishFailure', { reason: error }),
+      {
+        source: 'feed',
+        context,
+        metadata: { reason: error },
+        deliver: { email: true },
+      },
+    );
   }
 
-  private fetchPage(options: { cursor?: string | null; append?: boolean; replace?: boolean }): void {
+  private fetchPage(options: {
+    cursor?: string | null;
+    append?: boolean;
+    replace?: boolean;
+  }): void {
     const { cursor, append, replace } = options;
     const filters = this.filtersSig();
     const params = this.buildParams({ ...filters, cursor });
@@ -556,7 +572,7 @@ export class FeedRealtimeService {
       this.store.dispatch(FeedActions.loadInitial({ replace: true }));
     } else {
       this.store.dispatch(
-        FeedActions.loadPage({ cursor: cursor ?? null, append: Boolean(append) })
+        FeedActions.loadPage({ cursor: cursor ?? null, append: Boolean(append) }),
       );
     }
     if (this.useMockFeed) {
@@ -569,26 +585,29 @@ export class FeedRealtimeService {
     }
     const url = this.composeUrl(COLLECTION_ENDPOINT);
     const context = createSilentHttpContext();
-    this.http
-      .get<ItemResponse>(url, { params, context })
-      .subscribe({
-        next: response => {
-          const items = this.normalizeArrayResponse(response?.data);
-          const nextCursor = response?.cursor ?? null;
-          this.store.dispatch(FeedActions.loadSuccess({ items, cursor: nextCursor, append: Boolean(append) }));
-          this.emitAnalytics('feed.page.loaded', { count: items.length, cursor: nextCursor });
-        },
-        error: error => {
-          const message = this.extractError(error);
-          this.store.dispatch(FeedActions.loadFailure({ error: message }));
-          this.notifications.error(this.translate.instant('feed.notifications.loadError', { reason: message }), {
+    this.http.get<ItemResponse>(url, { params, context }).subscribe({
+      next: (response) => {
+        const items = this.normalizeArrayResponse(response?.data);
+        const nextCursor = response?.cursor ?? null;
+        this.store.dispatch(
+          FeedActions.loadSuccess({ items, cursor: nextCursor, append: Boolean(append) }),
+        );
+        this.emitAnalytics('feed.page.loaded', { count: items.length, cursor: nextCursor });
+      },
+      error: (error) => {
+        const message = this.extractError(error);
+        this.store.dispatch(FeedActions.loadFailure({ error: message }));
+        this.notifications.error(
+          this.translate.instant('feed.notifications.loadError', { reason: message }),
+          {
             source: 'feed',
             context: error,
             metadata: { cursor, append },
             deliver: { email: true },
-          });
-        },
-      });
+          },
+        );
+      },
+    });
   }
 
   private async resolveAndDispatchMockPage(options: {
@@ -614,18 +633,25 @@ export class FeedRealtimeService {
           items,
           cursor: nextCursor,
           append,
-        })
+        }),
       );
-      this.emitAnalytics('feed.page.loaded', { count: items.length, cursor: nextCursor, source: 'mock' });
+      this.emitAnalytics('feed.page.loaded', {
+        count: items.length,
+        cursor: nextCursor,
+        source: 'mock',
+      });
     } catch (error) {
       const message = this.extractError(error);
       this.store.dispatch(FeedActions.loadFailure({ error: message }));
-      this.notifications.error(this.translate.instant('feed.notifications.loadError', { reason: message }), {
-        source: 'feed',
-        context: error,
-        metadata: { cursor, append, source: 'mock' },
-        deliver: { email: true },
-      });
+      this.notifications.error(
+        this.translate.instant('feed.notifications.loadError', { reason: message }),
+        {
+          source: 'feed',
+          context: error,
+          metadata: { cursor, append, source: 'mock' },
+          deliver: { email: true },
+        },
+      );
     }
   }
 
@@ -652,17 +678,21 @@ export class FeedRealtimeService {
     this.store.dispatch(FeedActions.setConnectionStatus({ connected: false, reconnecting: true }));
     this.eventSource.onopen = () =>
       this.zone.run(() => {
-        this.store.dispatch(FeedActions.setConnectionStatus({ connected: true, reconnecting: false }));
+        this.store.dispatch(
+          FeedActions.setConnectionStatus({ connected: true, reconnecting: false }),
+        );
         this.reconnectAttempts = 0;
         this.notifyConnectionRestored('sse');
       });
     this.eventSource.onerror = () =>
       this.zone.run(() => {
-        this.store.dispatch(FeedActions.setConnectionStatus({ connected: false, reconnecting: true }));
+        this.store.dispatch(
+          FeedActions.setConnectionStatus({ connected: false, reconnecting: true }),
+        );
         this.notifyConnectionLost('sse');
         this.scheduleReconnect();
       });
-    this.eventSource.onmessage = event =>
+    this.eventSource.onmessage = (event) =>
       this.zone.run(() => {
         this.handleIncomingEvent(event.data, event.lastEventId ?? undefined);
       });
@@ -680,22 +710,28 @@ export class FeedRealtimeService {
     this.store.dispatch(FeedActions.setConnectionStatus({ connected: false, reconnecting: true }));
     this.socket.onopen = () =>
       this.zone.run(() => {
-        this.store.dispatch(FeedActions.setConnectionStatus({ connected: true, reconnecting: false }));
+        this.store.dispatch(
+          FeedActions.setConnectionStatus({ connected: true, reconnecting: false }),
+        );
         this.reconnectAttempts = 0;
         this.notifyConnectionRestored('ws');
       });
     this.socket.onerror = () =>
       this.zone.run(() => {
-        this.store.dispatch(FeedActions.setConnectionStatus({ connected: false, reconnecting: true }));
+        this.store.dispatch(
+          FeedActions.setConnectionStatus({ connected: false, reconnecting: true }),
+        );
         this.notifyConnectionLost('ws');
       });
     this.socket.onclose = () =>
       this.zone.run(() => {
-        this.store.dispatch(FeedActions.setConnectionStatus({ connected: false, reconnecting: true }));
+        this.store.dispatch(
+          FeedActions.setConnectionStatus({ connected: false, reconnecting: true }),
+        );
         this.notifyConnectionLost('ws');
         this.scheduleReconnect();
       });
-    this.socket.onmessage = event =>
+    this.socket.onmessage = (event) =>
       this.zone.run(() => {
         this.handleIncomingEvent(event.data);
       });
@@ -710,7 +746,10 @@ export class FeedRealtimeService {
     }
     let envelope: FeedRealtimeEnvelope | null = null;
     try {
-      envelope = typeof raw === 'string' ? (JSON.parse(raw) as FeedRealtimeEnvelope) : (raw as FeedRealtimeEnvelope);
+      envelope =
+        typeof raw === 'string'
+          ? (JSON.parse(raw) as FeedRealtimeEnvelope)
+          : (raw as FeedRealtimeEnvelope);
     } catch (error) {
       console.warn('[feed] Failed to parse realtime payload', error);
       return;
@@ -745,10 +784,15 @@ export class FeedRealtimeService {
       this.connect();
     }, delay);
     if (attempt === 1) {
-      this.notifications.info(this.translate.instant('feed.notifications.reconnecting', { seconds: Math.round(delay / 1000) }), {
-        source: 'feed',
-        metadata: { attempt, delay },
-      });
+      this.notifications.info(
+        this.translate.instant('feed.notifications.reconnecting', {
+          seconds: Math.round(delay / 1000),
+        }),
+        {
+          source: 'feed',
+          metadata: { attempt, delay },
+        },
+      );
     }
   }
 
@@ -841,8 +885,8 @@ export class FeedRealtimeService {
 
     if (!this.mockFeedRequest) {
       this.mockFeedRequest = firstValueFrom(this.http.get<CatalogMockResponse>(CATALOG_MOCK_PATH))
-        .then(payload => this.normalizeArrayResponse(payload?.feedItems ?? []))
-        .then(items => {
+        .then((payload) => this.normalizeArrayResponse(payload?.feedItems ?? []))
+        .then((items) => {
           this.mockFeedCache = items;
           return items;
         })
@@ -856,7 +900,7 @@ export class FeedRealtimeService {
 
   private async resolveMockItemById(itemId: string): Promise<FeedItem | null> {
     const items = await this.resolveMockFeedItems();
-    const item = items.find(entry => entry.id === itemId);
+    const item = items.find((entry) => entry.id === itemId);
     return item ? this.normalizeItem(item) : null;
   }
 
@@ -880,12 +924,14 @@ export class FeedRealtimeService {
     return `${base}${path}`;
   }
 
-  private normalizeArrayResponse(data: FeedItem | readonly FeedItem[] | null | undefined): FeedItem[] {
+  private normalizeArrayResponse(
+    data: FeedItem | readonly FeedItem[] | null | undefined,
+  ): FeedItem[] {
     if (!data) {
       return [];
     }
     return Array.isArray(data)
-      ? data.map(item => this.normalizeItem(item))
+      ? data.map((item) => this.normalizeItem(item))
       : [this.normalizeItem(data as FeedItem)];
   }
 
@@ -924,7 +970,7 @@ export class FeedRealtimeService {
   private buildOptimisticItem(
     draft: FeedComposerDraft,
     key: string,
-    metadata: FeedPublicationMetadata | null
+    metadata: FeedPublicationMetadata | null,
   ): FeedItem {
     const now = new Date().toISOString();
     return {
@@ -970,7 +1016,9 @@ export class FeedRealtimeService {
     };
   }
 
-  private normalizePublicationMetadata(value: FeedPublicationMetadata | null | undefined): FeedPublicationMetadata | null {
+  private normalizePublicationMetadata(
+    value: FeedPublicationMetadata | null | undefined,
+  ): FeedPublicationMetadata | null {
     if (!value || typeof value !== 'object') {
       return null;
     }
@@ -1029,8 +1077,8 @@ export class FeedRealtimeService {
     if (Array.isArray(value)) {
       const normalized = value
         .slice(0, 50)
-        .map(entry => this.sanitizeMetadataValue(entry, depth + 1))
-        .filter(entry => entry !== undefined);
+        .map((entry) => this.sanitizeMetadataValue(entry, depth + 1))
+        .filter((entry) => entry !== undefined);
       return normalized.length ? normalized : undefined;
     }
     if (typeof value === 'object') {
@@ -1039,7 +1087,9 @@ export class FeedRealtimeService {
     return undefined;
   }
 
-  private normalizeOriginType(value: FeedOriginType | string | null | undefined): FeedOriginType | null {
+  private normalizeOriginType(
+    value: FeedOriginType | string | null | undefined,
+  ): FeedOriginType | null {
     if (typeof value !== 'string') {
       return null;
     }
@@ -1095,6 +1145,11 @@ export class FeedRealtimeService {
     return Math.random().toString(36).slice(2) + Date.now().toString(36);
   }
 
+  private normalizeIdempotencyKey(value: string | null | undefined): string | null {
+    const normalized = value?.trim();
+    return normalized ? normalized.slice(0, 140) : null;
+  }
+
   private equalFilters(a: FeedFilterState, b: FeedFilterState): boolean {
     return (
       a.fromProvinceId === b.fromProvinceId &&
@@ -1126,12 +1181,13 @@ export class FeedRealtimeService {
     }
   }
 
-
   private emitAnalytics(event: string, payload: Record<string, unknown>): void {
     this.analytics.emit(event, payload);
   }
 
-  private buildPublishAnalyticsPayload(source: PublishContext | FeedItem | null | undefined): Record<string, unknown> {
+  private buildPublishAnalyticsPayload(
+    source: PublishContext | FeedItem | null | undefined,
+  ): Record<string, unknown> {
     const metadata = source?.metadata ?? null;
     const formKey = metadata?.publicationForm?.formKey ?? null;
 

--- a/packages/contracts/spec/openapi.json
+++ b/packages/contracts/spec/openapi.json
@@ -428,6 +428,66 @@
         }
       }
     },
+    "/api/users/me/opportunity-offers": {
+      "get": {
+        "summary": "List opportunity offers for the authenticated user",
+        "parameters": [
+          {
+            "name": "opportunityId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityOfferCollectionResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Submit an offer for an opportunity",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityOfferCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityOfferResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/hydrocarbon-signals": {
       "get": {
         "summary": "List hydrocarbon publication projections",
@@ -1391,6 +1451,142 @@
           "metadata": { "$ref": "#/components/schemas/FeedPublicationMetadata", "nullable": true }
         },
         "required": ["type", "title", "summary", "mode"]
+      },
+      "OpportunityOfferActivityRecord": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "type": {
+            "type": "string",
+            "enum": [
+              "submitted",
+              "tracked",
+              "qualified",
+              "inDiscussion",
+              "partiallyServed",
+              "withdrawn"
+            ]
+          },
+          "actor": {
+            "type": "string",
+            "enum": ["sender", "system"]
+          },
+          "createdAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "type", "actor", "createdAt"]
+      },
+      "OpportunityOfferRecord": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "reference": { "type": "string" },
+          "opportunityId": { "type": "string" },
+          "opportunityTitle": { "type": "string" },
+          "opportunityRoute": { "type": "string", "nullable": true },
+          "feedItemId": { "type": "string", "nullable": true },
+          "recipientKind": {
+            "type": "string",
+            "enum": ["GOV", "COMPANY", "PARTNER", "USER"]
+          },
+          "recipientLabel": { "type": "string" },
+          "senderUserId": { "type": "string" },
+          "senderLabel": { "type": "string" },
+          "senderEmail": { "type": "string", "format": "email" },
+          "capacityMw": { "type": "number" },
+          "startDate": { "type": "string", "format": "date" },
+          "endDate": { "type": "string", "format": "date" },
+          "pricingModel": { "type": "string" },
+          "comment": { "type": "string" },
+          "attachmentId": { "type": "string", "nullable": true },
+          "attachmentName": { "type": "string", "nullable": true },
+          "status": {
+            "type": "string",
+            "enum": ["submitted", "inDiscussion", "partiallyServed", "withdrawn"]
+          },
+          "allocatedCapacityMw": { "type": "number", "nullable": true },
+          "remainingOpportunityCapacityMw": { "type": "number", "nullable": true },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "submittedAt": { "type": "string", "format": "date-time" },
+          "withdrawnAt": { "type": "string", "nullable": true, "format": "date-time" },
+          "activities": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OpportunityOfferActivityRecord" }
+          },
+          "correlationId": { "type": "string", "nullable": true },
+          "idempotencyKey": { "type": "string", "nullable": true }
+        },
+        "required": [
+          "id",
+          "reference",
+          "opportunityId",
+          "opportunityTitle",
+          "recipientKind",
+          "recipientLabel",
+          "senderUserId",
+          "senderLabel",
+          "senderEmail",
+          "capacityMw",
+          "startDate",
+          "endDate",
+          "pricingModel",
+          "comment",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "submittedAt",
+          "activities"
+        ]
+      },
+      "OpportunityOfferCreateRequest": {
+        "type": "object",
+        "properties": {
+          "opportunityId": { "type": "string" },
+          "opportunityTitle": { "type": "string" },
+          "opportunityRoute": { "type": "string", "nullable": true },
+          "feedItemId": { "type": "string", "nullable": true },
+          "recipientKind": {
+            "type": "string",
+            "enum": ["GOV", "COMPANY", "PARTNER", "USER"]
+          },
+          "recipientLabel": { "type": "string" },
+          "capacityMw": { "type": "number", "minimum": 0 },
+          "startDate": { "type": "string", "format": "date" },
+          "endDate": { "type": "string", "format": "date" },
+          "pricingModel": { "type": "string" },
+          "comment": { "type": "string" },
+          "attachmentId": { "type": "string", "nullable": true },
+          "attachmentName": { "type": "string", "nullable": true },
+          "correlationId": { "type": "string", "nullable": true }
+        },
+        "required": [
+          "opportunityId",
+          "opportunityTitle",
+          "recipientKind",
+          "recipientLabel",
+          "capacityMw",
+          "startDate",
+          "endDate",
+          "pricingModel",
+          "comment"
+        ]
+      },
+      "OpportunityOfferResponse": {
+        "type": "object",
+        "properties": {
+          "data": { "$ref": "#/components/schemas/OpportunityOfferRecord" }
+        },
+        "required": ["data"]
+      },
+      "OpportunityOfferCollectionResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OpportunityOfferRecord" }
+          }
+        },
+        "required": ["data"]
       },
       "BillingPlanPrice": {
         "type": "object",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,8 +3,8 @@ import type { components } from './strapi.rest';
 
 // Types de haut niveau (facultatif)
 export type Province = components['schemas']['Province'];
-export type Sector   = components['schemas']['Sector'];
-export type Company  = components['schemas']['Company'];
+export type Sector = components['schemas']['Sector'];
+export type Company = components['schemas']['Company'];
 export type Exchange = components['schemas']['Exchange'];
 export type BillingPlan = components['schemas']['BillingPlan'];
 export type BillingPlanCapabilities = components['schemas']['BillingPlanCapabilities'];
@@ -15,20 +15,29 @@ export type StatisticsSnapshot = components['schemas']['StatisticsSnapshot'];
 export type StatisticsResponse = components['schemas']['StatisticsResponse'];
 export type HydrocarbonSignal = components['schemas']['HydrocarbonSignal'];
 export type HydrocarbonSignalResponse = components['schemas']['HydrocarbonSignalResponse'];
-export type HydrocarbonSignalCollectionResponse = components['schemas']['HydrocarbonSignalCollectionResponse'];
+export type HydrocarbonSignalCollectionResponse =
+  components['schemas']['HydrocarbonSignalCollectionResponse'];
+export type OpportunityOfferRecord = components['schemas']['OpportunityOfferRecord'];
 
 // Réponses Strapi usuelles
-export interface StrapiList<T> { data: T[]; meta: { pagination?: unknown } }
-export interface StrapiSingle<T> { data: T;  meta?: unknown }
+export interface StrapiList<T> {
+  data: T[];
+  meta: { pagination?: unknown };
+}
+export interface StrapiSingle<T> {
+  data: T;
+  meta?: unknown;
+}
 
 // Endpoints documentés
 export const endpoints = {
-  sectors:   '/api/sectors',
+  sectors: '/api/sectors',
   provinces: '/api/provinces',
   companies: '/api/companies',
   exchanges: '/api/exchanges',
-  homepage:  '/api/homepage',
+  homepage: '/api/homepage',
   statistics: '/api/statistics',
   billingPlans: '/billing/plans',
-  hydrocarbonSignals: '/api/hydrocarbon-signals'
+  hydrocarbonSignals: '/api/hydrocarbon-signals',
+  opportunityOffers: '/api/users/me/opportunity-offers',
 } as const;

--- a/packages/contracts/src/strapi.rest.d.ts
+++ b/packages/contracts/src/strapi.rest.d.ts
@@ -665,6 +665,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users/me/opportunity-offers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List opportunity offers for the authenticated user */
+        get: {
+            parameters: {
+                query?: {
+                    opportunityId?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OpportunityOfferCollectionResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Submit an offer for an opportunity */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    "Idempotency-Key"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["OpportunityOfferCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OpportunityOfferResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/hydrocarbon-signals": {
         parameters: {
             query?: never;
@@ -1471,6 +1535,79 @@ export interface components {
             originId?: string | null;
             connectionMatchId?: number | null;
             metadata?: components["schemas"]["FeedPublicationMetadata"];
+        };
+        OpportunityOfferActivityRecord: {
+            id: string;
+            /** @enum {string} */
+            type: "submitted" | "tracked" | "qualified" | "inDiscussion" | "partiallyServed" | "withdrawn";
+            /** @enum {string} */
+            actor: "sender" | "system";
+            /** Format: date-time */
+            createdAt: string;
+        };
+        OpportunityOfferRecord: {
+            id: string;
+            reference: string;
+            opportunityId: string;
+            opportunityTitle: string;
+            opportunityRoute?: string | null;
+            feedItemId?: string | null;
+            /** @enum {string} */
+            recipientKind: "GOV" | "COMPANY" | "PARTNER" | "USER";
+            recipientLabel: string;
+            senderUserId: string;
+            senderLabel: string;
+            /** Format: email */
+            senderEmail: string;
+            capacityMw: number;
+            /** Format: date */
+            startDate: string;
+            /** Format: date */
+            endDate: string;
+            pricingModel: string;
+            comment: string;
+            attachmentId?: string | null;
+            attachmentName?: string | null;
+            /** @enum {string} */
+            status: "submitted" | "inDiscussion" | "partiallyServed" | "withdrawn";
+            allocatedCapacityMw?: number | null;
+            remainingOpportunityCapacityMw?: number | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            /** Format: date-time */
+            submittedAt: string;
+            /** Format: date-time */
+            withdrawnAt?: string | null;
+            activities: components["schemas"]["OpportunityOfferActivityRecord"][];
+            correlationId?: string | null;
+            idempotencyKey?: string | null;
+        };
+        OpportunityOfferCreateRequest: {
+            opportunityId: string;
+            opportunityTitle: string;
+            opportunityRoute?: string | null;
+            feedItemId?: string | null;
+            /** @enum {string} */
+            recipientKind: "GOV" | "COMPANY" | "PARTNER" | "USER";
+            recipientLabel: string;
+            capacityMw: number;
+            /** Format: date */
+            startDate: string;
+            /** Format: date */
+            endDate: string;
+            pricingModel: string;
+            comment: string;
+            attachmentId?: string | null;
+            attachmentName?: string | null;
+            correlationId?: string | null;
+        };
+        OpportunityOfferResponse: {
+            data: components["schemas"]["OpportunityOfferRecord"];
+        };
+        OpportunityOfferCollectionResponse: {
+            data: components["schemas"]["OpportunityOfferRecord"][];
         };
         BillingPlanPrice: {
             amount: number;

--- a/strapi/src/api/opportunity-offer/content-types/opportunity-offer/schema.ts
+++ b/strapi/src/api/opportunity-offer/content-types/opportunity-offer/schema.ts
@@ -1,0 +1,124 @@
+import type { Struct } from '@strapi/strapi';
+
+const schema = {
+  kind: 'collectionType',
+  collectionName: 'opportunity_offers',
+  modelType: 'contentType',
+  uid: 'api::opportunity-offer.opportunity-offer',
+  modelName: 'opportunity-offer',
+  globalId: 'OpportunityOffer',
+  info: {
+    singularName: 'opportunity-offer',
+    pluralName: 'opportunity-offers',
+    displayName: 'Opportunity Offer',
+  },
+  options: {
+    draftAndPublish: false,
+  },
+  attributes: {
+    user: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'plugin::users-permissions.user',
+      required: true,
+    },
+    reference: {
+      type: 'string',
+      required: true,
+      unique: true,
+    },
+    opportunityId: {
+      type: 'string',
+      required: true,
+    },
+    opportunityTitle: {
+      type: 'string',
+      required: true,
+    },
+    opportunityRoute: {
+      type: 'string',
+    },
+    feedItemId: {
+      type: 'string',
+    },
+    recipientKind: {
+      type: 'enumeration',
+      enum: ['GOV', 'COMPANY', 'PARTNER', 'USER'],
+      default: 'PARTNER',
+      required: true,
+    },
+    recipientLabel: {
+      type: 'string',
+      required: true,
+    },
+    senderUserId: {
+      type: 'string',
+      required: true,
+    },
+    senderLabel: {
+      type: 'string',
+      required: true,
+    },
+    senderEmail: {
+      type: 'email',
+      required: true,
+    },
+    capacityMw: {
+      type: 'decimal',
+      required: true,
+      min: 0,
+    },
+    startDate: {
+      type: 'date',
+      required: true,
+    },
+    endDate: {
+      type: 'date',
+      required: true,
+    },
+    pricingModel: {
+      type: 'string',
+      required: true,
+    },
+    comment: {
+      type: 'text',
+      required: true,
+    },
+    attachmentId: {
+      type: 'string',
+    },
+    attachmentName: {
+      type: 'string',
+    },
+    status: {
+      type: 'enumeration',
+      enum: ['submitted', 'inDiscussion', 'partiallyServed', 'withdrawn'],
+      default: 'submitted',
+      required: true,
+    },
+    allocatedCapacityMw: {
+      type: 'decimal',
+    },
+    remainingOpportunityCapacityMw: {
+      type: 'decimal',
+    },
+    submittedAt: {
+      type: 'datetime',
+      required: true,
+    },
+    withdrawnAt: {
+      type: 'datetime',
+    },
+    activities: {
+      type: 'json',
+    },
+    correlationId: {
+      type: 'string',
+    },
+    idempotencyKey: {
+      type: 'string',
+    },
+  },
+} as unknown as Struct.CollectionTypeSchema;
+
+export default schema;

--- a/strapi/src/api/opportunity-offer/controllers/opportunity-offer.ts
+++ b/strapi/src/api/opportunity-offer/controllers/opportunity-offer.ts
@@ -1,0 +1,334 @@
+import type { Core } from '@strapi/strapi';
+
+const OPPORTUNITY_OFFER_UID = 'api::opportunity-offer.opportunity-offer' as any;
+const RECIPIENT_KINDS = new Set(['GOV', 'COMPANY', 'PARTNER', 'USER']);
+const STATUS_SUBMITTED = 'submitted';
+
+interface AuthenticatedUser {
+  id: number | string;
+  email?: string | null;
+  username?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+}
+
+interface OpportunityOfferPayload {
+  opportunityId: string;
+  opportunityTitle: string;
+  opportunityRoute: string | null;
+  feedItemId: string | null;
+  recipientKind: 'GOV' | 'COMPANY' | 'PARTNER' | 'USER';
+  recipientLabel: string;
+  capacityMw: number;
+  startDate: string;
+  endDate: string;
+  pricingModel: string;
+  comment: string;
+  attachmentId: string | null;
+  attachmentName: string | null;
+  correlationId: string | null;
+}
+
+interface OpportunityOfferEntity extends Record<string, unknown> {
+  id: number | string;
+}
+
+function normalizeString(value: unknown, maxLength = 500): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized.slice(0, maxLength) : null;
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const parsed = Number.parseFloat(value.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeDateOnly(value: unknown): string | null {
+  const normalized = normalizeString(value, 20);
+  if (!normalized || !/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    return null;
+  }
+  const timestamp = Date.parse(`${normalized}T00:00:00.000Z`);
+  return Number.isFinite(timestamp) ? normalized : null;
+}
+
+function normalizeRecipientKind(value: unknown): OpportunityOfferPayload['recipientKind'] {
+  const normalized = normalizeString(value, 24)?.toUpperCase();
+  if (!normalized || !RECIPIENT_KINDS.has(normalized)) {
+    return 'PARTNER';
+  }
+  return normalized as OpportunityOfferPayload['recipientKind'];
+}
+
+function normalizeFindManyResult<T>(value: T | T[] | null | undefined): T[] {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeIdempotencyKey(ctx: Record<string, unknown>): string | null {
+  const headers =
+    ctx.request && typeof ctx.request === 'object'
+      ? (((ctx.request as Record<string, unknown>).header as Record<string, unknown>) ?? {})
+      : {};
+  return normalizeString(headers['idempotency-key'], 140);
+}
+
+function sanitizePayload(payload: unknown): OpportunityOfferPayload {
+  const record = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {};
+  const opportunityId = normalizeString(record.opportunityId, 160);
+  const opportunityTitle = normalizeString(record.opportunityTitle, 180);
+  const recipientLabel = normalizeString(record.recipientLabel, 180);
+  const capacityMw = normalizeNumber(record.capacityMw);
+  const startDate = normalizeDateOnly(record.startDate);
+  const endDate = normalizeDateOnly(record.endDate);
+  const pricingModel = normalizeString(record.pricingModel, 80);
+  const comment = normalizeString(record.comment, 5000);
+
+  if (!opportunityId) {
+    throw new Error('opportunityId is required.');
+  }
+  if (!opportunityTitle) {
+    throw new Error('opportunityTitle is required.');
+  }
+  if (!recipientLabel) {
+    throw new Error('recipientLabel is required.');
+  }
+  if (capacityMw == null || capacityMw <= 0) {
+    throw new Error('capacityMw must be greater than 0.');
+  }
+  if (!startDate) {
+    throw new Error('startDate must be a YYYY-MM-DD date.');
+  }
+  if (!endDate) {
+    throw new Error('endDate must be a YYYY-MM-DD date.');
+  }
+  if (endDate < startDate) {
+    throw new Error('endDate must be on or after startDate.');
+  }
+  if (!pricingModel) {
+    throw new Error('pricingModel is required.');
+  }
+  if (!comment || comment.length < 10) {
+    throw new Error('comment must be at least 10 characters.');
+  }
+
+  return {
+    opportunityId,
+    opportunityTitle,
+    opportunityRoute: normalizeString(record.opportunityRoute, 240),
+    feedItemId: normalizeString(record.feedItemId, 160),
+    recipientKind: normalizeRecipientKind(record.recipientKind),
+    recipientLabel,
+    capacityMw,
+    startDate,
+    endDate,
+    pricingModel,
+    comment,
+    attachmentId: normalizeString(record.attachmentId, 160),
+    attachmentName: normalizeString(record.attachmentName, 220),
+    correlationId: normalizeString(record.correlationId, 160),
+  };
+}
+
+function buildSenderLabel(user: AuthenticatedUser): string {
+  const firstName = normalizeString(user.firstName, 80);
+  const lastName = normalizeString(user.lastName, 80);
+  const fullName = `${firstName ?? ''} ${lastName ?? ''}`.trim();
+  if (fullName) {
+    return fullName;
+  }
+  return (
+    normalizeString(user.email, 180) ??
+    normalizeString(user.username, 180) ??
+    `User ${String(user.id)}`
+  );
+}
+
+function buildSenderEmail(user: AuthenticatedUser): string {
+  return normalizeString(user.email, 180) ?? 'unknown@openg7.local';
+}
+
+function generateReference(referenceDateIso: string): string {
+  const date = new Date(referenceDateIso);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const suffix = Math.random().toString(36).slice(2, 6).toUpperCase();
+  return `OG7-OFR-${year}${month}${day}-${suffix}`;
+}
+
+function generateRecordId(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) {
+    return `${prefix}-${uuid}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
+}
+
+function createInitialActivities(createdAt: string) {
+  return [
+    {
+      id: generateRecordId('offer-activity'),
+      type: 'tracked',
+      actor: 'system',
+      createdAt,
+    },
+    {
+      id: generateRecordId('offer-activity'),
+      type: 'submitted',
+      actor: 'sender',
+      createdAt,
+    },
+  ];
+}
+
+function toOfferResponse(entity: OpportunityOfferEntity) {
+  return {
+    id: String(entity.id),
+    reference: typeof entity.reference === 'string' ? entity.reference : '',
+    opportunityId: typeof entity.opportunityId === 'string' ? entity.opportunityId : '',
+    opportunityTitle: typeof entity.opportunityTitle === 'string' ? entity.opportunityTitle : '',
+    opportunityRoute: typeof entity.opportunityRoute === 'string' ? entity.opportunityRoute : null,
+    feedItemId: typeof entity.feedItemId === 'string' ? entity.feedItemId : null,
+    recipientKind: RECIPIENT_KINDS.has(String(entity.recipientKind))
+      ? entity.recipientKind
+      : 'PARTNER',
+    recipientLabel: typeof entity.recipientLabel === 'string' ? entity.recipientLabel : '',
+    senderUserId: typeof entity.senderUserId === 'string' ? entity.senderUserId : '',
+    senderLabel: typeof entity.senderLabel === 'string' ? entity.senderLabel : '',
+    senderEmail: typeof entity.senderEmail === 'string' ? entity.senderEmail : '',
+    capacityMw: normalizeNumber(entity.capacityMw) ?? 0,
+    startDate: typeof entity.startDate === 'string' ? entity.startDate : '',
+    endDate: typeof entity.endDate === 'string' ? entity.endDate : '',
+    pricingModel: typeof entity.pricingModel === 'string' ? entity.pricingModel : '',
+    comment: typeof entity.comment === 'string' ? entity.comment : '',
+    attachmentId: typeof entity.attachmentId === 'string' ? entity.attachmentId : null,
+    attachmentName: typeof entity.attachmentName === 'string' ? entity.attachmentName : null,
+    status: typeof entity.status === 'string' ? entity.status : STATUS_SUBMITTED,
+    allocatedCapacityMw: normalizeNumber(entity.allocatedCapacityMw),
+    remainingOpportunityCapacityMw: normalizeNumber(entity.remainingOpportunityCapacityMw),
+    createdAt: typeof entity.createdAt === 'string' ? entity.createdAt : '',
+    updatedAt: typeof entity.updatedAt === 'string' ? entity.updatedAt : '',
+    submittedAt: typeof entity.submittedAt === 'string' ? entity.submittedAt : '',
+    withdrawnAt: typeof entity.withdrawnAt === 'string' ? entity.withdrawnAt : null,
+    activities: Array.isArray(entity.activities) ? entity.activities : [],
+    correlationId: typeof entity.correlationId === 'string' ? entity.correlationId : null,
+    idempotencyKey: typeof entity.idempotencyKey === 'string' ? entity.idempotencyKey : null,
+  };
+}
+
+export default ({ strapi }: { strapi: Core.Strapi }) => ({
+  async me(ctx) {
+    const currentUser = ctx.state.user as AuthenticatedUser | undefined;
+    if (!currentUser?.id) {
+      return ctx.unauthorized();
+    }
+
+    const query = ctx.request?.query ?? {};
+    const opportunityId = normalizeString((query as Record<string, unknown>).opportunityId, 160);
+    const filters: Record<string, unknown> = {
+      user: {
+        id: currentUser.id,
+      },
+    };
+    if (opportunityId) {
+      filters.opportunityId = opportunityId;
+    }
+
+    const entries = await strapi.entityService.findMany(OPPORTUNITY_OFFER_UID, {
+      filters,
+      sort: ['updatedAt:desc', 'createdAt:desc'],
+    });
+
+    ctx.body = {
+      data: normalizeFindManyResult(entries).map((entry) =>
+        toOfferResponse(entry as OpportunityOfferEntity),
+      ),
+    };
+  },
+
+  async createMe(ctx) {
+    const currentUser = ctx.state.user as AuthenticatedUser | undefined;
+    if (!currentUser?.id) {
+      return ctx.unauthorized();
+    }
+
+    let payload: OpportunityOfferPayload;
+    try {
+      payload = sanitizePayload(ctx.request.body);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Invalid opportunity offer payload.';
+      return ctx.badRequest(message);
+    }
+
+    const idempotencyKey = normalizeIdempotencyKey(ctx);
+    if (idempotencyKey) {
+      const existing = normalizeFindManyResult(
+        await strapi.entityService.findMany(OPPORTUNITY_OFFER_UID, {
+          filters: {
+            user: { id: currentUser.id },
+            idempotencyKey,
+          },
+          sort: ['createdAt:desc'],
+          limit: 1,
+        }),
+      )[0] as OpportunityOfferEntity | undefined;
+
+      if (existing) {
+        ctx.body = {
+          data: toOfferResponse(existing),
+        };
+        return;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const created = await strapi.entityService.create(OPPORTUNITY_OFFER_UID, {
+      data: {
+        user: currentUser.id,
+        reference: generateReference(now),
+        opportunityId: payload.opportunityId,
+        opportunityTitle: payload.opportunityTitle,
+        opportunityRoute: payload.opportunityRoute,
+        feedItemId: payload.feedItemId,
+        recipientKind: payload.recipientKind,
+        recipientLabel: payload.recipientLabel,
+        senderUserId: String(currentUser.id),
+        senderLabel: buildSenderLabel(currentUser),
+        senderEmail: buildSenderEmail(currentUser),
+        capacityMw: payload.capacityMw,
+        startDate: payload.startDate,
+        endDate: payload.endDate,
+        pricingModel: payload.pricingModel,
+        comment: payload.comment,
+        attachmentId: payload.attachmentId,
+        attachmentName: payload.attachmentName,
+        status: STATUS_SUBMITTED,
+        allocatedCapacityMw: null,
+        remainingOpportunityCapacityMw: null,
+        submittedAt: now,
+        withdrawnAt: null,
+        activities: createInitialActivities(now),
+        correlationId: payload.correlationId,
+        idempotencyKey,
+      } as any,
+    });
+
+    ctx.status = 201;
+    ctx.body = {
+      data: toOfferResponse(created as OpportunityOfferEntity),
+    };
+  },
+});

--- a/strapi/src/api/opportunity-offer/routes/opportunity-offer.ts
+++ b/strapi/src/api/opportunity-offer/routes/opportunity-offer.ts
@@ -1,0 +1,16 @@
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/users/me/opportunity-offers',
+      handler: 'opportunity-offer.me',
+      config: {},
+    },
+    {
+      method: 'POST',
+      path: '/users/me/opportunity-offers',
+      handler: 'opportunity-offer.createMe',
+      config: {},
+    },
+  ],
+};

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1047,6 +1047,71 @@ export interface ApiNationalProjectNationalProject extends Struct.CollectionType
   };
 }
 
+export interface ApiOpportunityOfferOpportunityOffer extends Struct.CollectionTypeSchema {
+  collectionName: 'opportunity_offers';
+  info: {
+    displayName: 'Opportunity Offer';
+    pluralName: 'opportunity-offers';
+    singularName: 'opportunity-offer';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    activities: Schema.Attribute.JSON;
+    allocatedCapacityMw: Schema.Attribute.Decimal;
+    attachmentId: Schema.Attribute.String;
+    attachmentName: Schema.Attribute.String;
+    capacityMw: Schema.Attribute.Decimal &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 0;
+        },
+        number
+      >;
+    comment: Schema.Attribute.Text & Schema.Attribute.Required;
+    correlationId: Schema.Attribute.String;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> & Schema.Attribute.Private;
+    endDate: Schema.Attribute.Date & Schema.Attribute.Required;
+    feedItemId: Schema.Attribute.String;
+    idempotencyKey: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::opportunity-offer.opportunity-offer'
+    > &
+      Schema.Attribute.Private;
+    opportunityId: Schema.Attribute.String & Schema.Attribute.Required;
+    opportunityRoute: Schema.Attribute.String;
+    opportunityTitle: Schema.Attribute.String & Schema.Attribute.Required;
+    pricingModel: Schema.Attribute.String & Schema.Attribute.Required;
+    publishedAt: Schema.Attribute.DateTime;
+    recipientKind: Schema.Attribute.Enumeration<['GOV', 'COMPANY', 'PARTNER', 'USER']> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'PARTNER'>;
+    recipientLabel: Schema.Attribute.String & Schema.Attribute.Required;
+    reference: Schema.Attribute.String & Schema.Attribute.Required & Schema.Attribute.Unique;
+    remainingOpportunityCapacityMw: Schema.Attribute.Decimal;
+    senderEmail: Schema.Attribute.Email & Schema.Attribute.Required;
+    senderLabel: Schema.Attribute.String & Schema.Attribute.Required;
+    senderUserId: Schema.Attribute.String & Schema.Attribute.Required;
+    startDate: Schema.Attribute.Date & Schema.Attribute.Required;
+    status: Schema.Attribute.Enumeration<
+      ['submitted', 'inDiscussion', 'partiallyServed', 'withdrawn']
+    > &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'submitted'>;
+    submittedAt: Schema.Attribute.DateTime & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> & Schema.Attribute.Private;
+    user: Schema.Attribute.Relation<'manyToOne', 'plugin::users-permissions.user'> &
+      Schema.Attribute.Required;
+    withdrawnAt: Schema.Attribute.DateTime;
+  };
+}
+
 export interface ApiProvinceProvince extends Struct.CollectionTypeSchema {
   collectionName: 'provinces';
   info: {
@@ -1697,6 +1762,7 @@ declare module '@strapi/strapi' {
       'api::import-report-schedule.import-report-schedule': ApiImportReportScheduleImportReportSchedule;
       'api::import-watchlist.import-watchlist': ApiImportWatchlistImportWatchlist;
       'api::national-project.national-project': ApiNationalProjectNationalProject;
+      'api::opportunity-offer.opportunity-offer': ApiOpportunityOfferOpportunityOffer;
       'api::province.province': ApiProvinceProvince;
       'api::saved-search.saved-search': ApiSavedSearchSavedSearch;
       'api::sector.sector': ApiSectorSector;


### PR DESCRIPTION
…offers

- Implemented GET /api/users/me/opportunity-offers to list opportunity offers for the authenticated user.
- Implemented POST /api/users/me/opportunity-offers to submit an offer for an opportunity with idempotency key support.
- Added OpportunityOffer schemas for request and response handling.
- Created OpportunityOffer service in Angular for API interaction.
- Developed Strapi controller and routes for opportunity offers management.
- Added unit tests for the OpportunityOffersApiService.

## Summary
Describe the change (scope, motivation, user or technical impact).

## Details / decisions
- Design choices or tradeoffs
- Documentation or configuration impact

## Anti-duplication checklist
- [ ] I reviewed docs/ecosystem/ECOSYSTEM-MAP.md
- [ ] I confirmed whether this capability already has a canonical repo
- [ ] If reusable by 2+ repos, I proposed a shared @openg7/* package instead of copy/paste
- [ ] I did not introduce canonical domain logic into openg7-nexus

## Tests
- [ ] `yarn lint`
- [ ] `yarn format:check`
- [ ] `yarn validate:selectors`
- [ ] `yarn codegen && yarn test`
- [ ] `yarn predeploy:cms-cache`
- [ ] `yarn prebuild:web`
- [ ] Other (specify):

## Review
- [ ] Docs updated (README, docs, or comments)
- [ ] Screenshot attached if UI
- [ ] Linked issue referenced
