### PR TITLE
feat: add Codex live timeline component and service

### DIFF
--- a/openg7-org/src/app/app.component.html
+++ b/openg7-org/src/app/app.component.html
@@ -55,6 +55,7 @@
         <span>Â© {{ currentYear }} OpenG7</span>
       </div>
     </footer>
+    <og7-codex-live-timeline></og7-codex-live-timeline>
     <og7-notification-toast-tray></og7-notification-toast-tray>
     <og7-modal-container></og7-modal-container>
   </div>

--- a/openg7-org/src/app/app.component.spec.ts
+++ b/openg7-org/src/app/app.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { AppComponent } from './app.component';
 import { FEATURE_FLAGS } from './core/config/environment.tokens';
 import { GlobalShortcutsService } from './core/shortcuts/global-shortcuts.service';
+import { AdminQualityHomeAgentService } from './domains/admin/data-access/admin-quality-home-agent.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -26,6 +27,7 @@ describe('AppComponent', () => {
           },
         },
         { provide: GlobalShortcutsService, useValue: {} },
+        { provide: AdminQualityHomeAgentService, useValue: {} },
         { provide: FEATURE_FLAGS, useValue: {} },
       ],
     })

--- a/openg7-org/src/app/app.component.ts
+++ b/openg7-org/src/app/app.component.ts
@@ -14,6 +14,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { NavigationEnd, Router, RouterLink, RouterOutlet } from '@angular/router';
+import { CodexLiveTimelineComponent } from '@app/shared/components/layout/codex-live-timeline/codex-live-timeline.component';
 import { NotificationToastTrayComponent } from '@app/shared/components/layout/notification-toast-tray/notification-toast-tray.component';
 import { Og7OnboardingFlowComponent } from '@app/shared/components/layout/og7-onboarding-flow/og7-onboarding-flow.component';
 import { SiteHeaderComponent } from '@app/shared/components/layout/site-header/site-header.component';
@@ -38,6 +39,7 @@ import { AdminQualityHomeAgentService } from './domains/admin/data-access/admin-
     SiteHeaderComponent,
     UnderConstructionBannerComponent,
     Og7OnboardingFlowComponent,
+    CodexLiveTimelineComponent,
     NotificationToastTrayComponent,
     Og7ModalContainerComponent,
     RouterLink,

--- a/openg7-org/src/app/core/observability/codex-live-timeline.service.ts
+++ b/openg7-org/src/app/core/observability/codex-live-timeline.service.ts
@@ -1,0 +1,437 @@
+import { Injectable, computed, signal } from '@angular/core';
+import {
+  GithubActionNotificationState,
+  GithubActionNotificationStatus,
+} from './github-action-notification-status';
+
+export type CodexLiveTimelineStepState = 'pending' | 'active' | 'completed' | 'failed';
+
+export interface CodexLiveTimelineStep {
+  readonly id: string;
+  readonly label: string;
+  readonly detail: string;
+  readonly state: CodexLiveTimelineStepState;
+  readonly startedAt: number | null;
+  readonly completedAt: number | null;
+}
+
+export interface CodexLiveTimelineEvent {
+  readonly id: string;
+  readonly createdAt: number;
+  readonly label: string;
+  readonly state: CodexLiveTimelineStepState;
+}
+
+export interface CodexLiveTimelineRun {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly provider: string;
+  readonly source: string | null;
+  readonly workflow: string | null;
+  readonly ref: string | null;
+  readonly runNumber: number | null;
+  readonly runUrl: string | null;
+  readonly pullRequestNumber: number | null;
+  readonly pullRequestUrl: string | null;
+  readonly startedAt: number;
+  readonly updatedAt: number;
+  readonly terminalState: GithubActionNotificationState | null;
+  readonly steps: readonly CodexLiveTimelineStep[];
+  readonly events: readonly CodexLiveTimelineEvent[];
+}
+
+export interface StartCodexLiveTimelineInput {
+  readonly provider: string;
+  readonly task: string;
+  readonly source?: string | null;
+  readonly actionLabel?: string | null;
+}
+
+export interface CodexLiveTimelineDispatchInfo {
+  readonly workflow: string;
+  readonly ref: string;
+}
+
+export interface CodexLiveTimelinePullRequestInfo {
+  readonly number: number | null;
+  readonly url: string | null;
+  readonly title?: string | null;
+}
+
+const SYNTHETIC_STEP_DELAYS_MS = [900, 2_100, 3_600];
+const MAX_EVENTS = 18;
+
+@Injectable({ providedIn: 'root' })
+export class CodexLiveTimelineService {
+  private readonly runSig = signal<CodexLiveTimelineRun | null>(null);
+  private readonly openSig = signal(false);
+  private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+
+  readonly run = this.runSig.asReadonly();
+  readonly isOpen = this.openSig.asReadonly();
+  readonly hasActiveRun = computed(() => Boolean(this.runSig()));
+
+  start(input: StartCodexLiveTimelineInput): string {
+    this.clearTimers();
+
+    const now = Date.now();
+    const id = `codex-live-${now.toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const provider = this.providerLabel(input.provider);
+    const subtitle = input.actionLabel?.trim() || input.task.trim().slice(0, 110);
+    const steps = this.defaultSteps().map((step, index) =>
+      index === 0
+        ? {
+            ...step,
+            state: 'active' as const,
+            startedAt: now,
+          }
+        : step,
+    );
+
+    this.runSig.set({
+      id,
+      title: 'Deploiement du chantier',
+      subtitle: subtitle || `${provider} prepare le workflow.`,
+      provider,
+      source: input.source ?? null,
+      workflow: null,
+      ref: null,
+      runNumber: null,
+      runUrl: null,
+      pullRequestNumber: null,
+      pullRequestUrl: null,
+      startedAt: now,
+      updatedAt: now,
+      terminalState: null,
+      steps,
+      events: [
+        {
+          id: `${id}-event-start`,
+          createdAt: now,
+          label: 'Analyse du repo...',
+          state: 'active',
+        },
+      ],
+    });
+    this.openSig.set(true);
+    this.scheduleSyntheticProgress(id);
+
+    return id;
+  }
+
+  show(): void {
+    if (this.runSig()) {
+      this.openSig.set(true);
+    }
+  }
+
+  hide(): void {
+    this.openSig.set(false);
+  }
+
+  clear(): void {
+    this.clearTimers();
+    this.runSig.set(null);
+    this.openSig.set(false);
+  }
+
+  recordDispatchQueued(
+    runId: string | null | undefined,
+    dispatch: CodexLiveTimelineDispatchInfo,
+  ): void {
+    this.updateRun(runId, (run) => {
+      const advanced = this.advanceToStep(run, 'tests');
+      return {
+        ...advanced,
+        workflow: dispatch.workflow,
+        ref: dispatch.ref,
+        subtitle: `${run.provider} envoye vers ${dispatch.workflow} sur ${dispatch.ref}.`,
+        events: this.appendEvent(
+          advanced,
+          `Dispatch GitHub Actions recu (${dispatch.workflow}).`,
+          'completed',
+        ),
+      };
+    });
+  }
+
+  recordDispatchError(runId: string | null | undefined, message: string): void {
+    this.updateRun(runId, (run) => this.failRun(run, message));
+  }
+
+  recordGithubStatus(
+    runId: string | null | undefined,
+    status: GithubActionNotificationStatus,
+  ): void {
+    this.updateRun(runId, (run) => {
+      const baseRun: CodexLiveTimelineRun = {
+        ...run,
+        workflow: status.workflow ?? run.workflow,
+        runNumber: status.runNumber ?? run.runNumber,
+        runUrl: status.runUrl ?? run.runUrl,
+        terminalState: this.isTerminal(status.state) ? status.state : null,
+      };
+
+      if (status.state === 'failed') {
+        return this.failRun(baseRun, status.detail || status.label);
+      }
+
+      if (status.state === 'completed') {
+        return this.completeRun(baseRun, status.detail || status.label);
+      }
+
+      const targetStep = status.state === 'in-progress' ? 'ci' : 'changes';
+      const advanced = this.advanceToStep(baseRun, targetStep);
+      return {
+        ...advanced,
+        events: this.appendEvent(advanced, status.detail || status.label, 'active'),
+      };
+    });
+  }
+
+  recordPullRequest(
+    runId: string | null | undefined,
+    pullRequest: CodexLiveTimelinePullRequestInfo,
+  ): void {
+    if (!pullRequest.number && !pullRequest.url) {
+      return;
+    }
+
+    this.updateRun(runId, (run) => {
+      const label = pullRequest.number
+        ? `Pull Request ouverte #${pullRequest.number}.`
+        : 'Pull Request ouverte.';
+      const completed = this.completeRun(run, label);
+      return {
+        ...completed,
+        pullRequestNumber: pullRequest.number,
+        pullRequestUrl: pullRequest.url,
+        events: this.appendEvent(completed, label, 'completed'),
+      };
+    });
+  }
+
+  private scheduleSyntheticProgress(runId: string): void {
+    const stepIds: ReadonlyArray<CodexLiveTimelineStep['id']> = ['files', 'tests', 'changes'];
+    SYNTHETIC_STEP_DELAYS_MS.forEach((delay, index) => {
+      const timer = setTimeout(() => {
+        this.timers.delete(timer);
+        this.updateRun(runId, (run) => this.advanceToStep(run, stepIds[index]));
+      }, delay);
+      this.timers.add(timer);
+    });
+  }
+
+  private updateRun(
+    runId: string | null | undefined,
+    updater: (run: CodexLiveTimelineRun) => CodexLiveTimelineRun,
+  ): void {
+    const current = this.runSig();
+    if (!current || current.id !== runId) {
+      return;
+    }
+
+    this.runSig.set({
+      ...updater(current),
+      updatedAt: Date.now(),
+    });
+  }
+
+  private advanceToStep(
+    run: CodexLiveTimelineRun,
+    targetStepId: CodexLiveTimelineStep['id'],
+  ): CodexLiveTimelineRun {
+    if (run.terminalState) {
+      return run;
+    }
+
+    const targetIndex = run.steps.findIndex((step) => step.id === targetStepId);
+    if (targetIndex < 0) {
+      return run;
+    }
+
+    const now = Date.now();
+    const steps = run.steps.map((step, index) => {
+      if (step.state === 'failed') {
+        return step;
+      }
+
+      if (index < targetIndex) {
+        return {
+          ...step,
+          state: 'completed' as const,
+          startedAt: step.startedAt ?? now,
+          completedAt: step.completedAt ?? now,
+        };
+      }
+
+      if (index === targetIndex) {
+        if (step.state === 'completed') {
+          return step;
+        }
+        return {
+          ...step,
+          state: 'active' as const,
+          startedAt: step.startedAt ?? now,
+        };
+      }
+
+      return step;
+    });
+
+    const activeStep = steps[targetIndex];
+    const eventLabel =
+      activeStep.state === 'active' ? `${activeStep.label}...` : `${activeStep.label}.`;
+
+    return {
+      ...run,
+      steps,
+      events: this.appendEvent(run, eventLabel, activeStep.state),
+    };
+  }
+
+  private completeRun(run: CodexLiveTimelineRun, message: string): CodexLiveTimelineRun {
+    this.clearTimers();
+    const now = Date.now();
+    const steps = run.steps.map((step) => ({
+      ...step,
+      state: 'completed' as const,
+      startedAt: step.startedAt ?? now,
+      completedAt: step.completedAt ?? now,
+    }));
+
+    return {
+      ...run,
+      terminalState: 'completed',
+      steps,
+      events: this.appendEvent(run, message, 'completed'),
+    };
+  }
+
+  private failRun(run: CodexLiveTimelineRun, message: string): CodexLiveTimelineRun {
+    this.clearTimers();
+    const now = Date.now();
+    let failedAssigned = false;
+    const steps = run.steps.map((step) => {
+      if (step.state === 'active' && !failedAssigned) {
+        failedAssigned = true;
+        return {
+          ...step,
+          state: 'failed' as const,
+          completedAt: now,
+        };
+      }
+      return step;
+    });
+
+    return {
+      ...run,
+      terminalState: 'failed',
+      steps,
+      events: this.appendEvent(run, message, 'failed'),
+    };
+  }
+
+  private appendEvent(
+    run: CodexLiveTimelineRun,
+    label: string,
+    state: CodexLiveTimelineStepState,
+  ): readonly CodexLiveTimelineEvent[] {
+    const trimmed = label.trim();
+    if (!trimmed) {
+      return run.events;
+    }
+
+    const last = run.events[run.events.length - 1];
+    if (last?.label === trimmed && last.state === state) {
+      return run.events;
+    }
+
+    return [
+      ...run.events,
+      {
+        id: `${run.id}-event-${Date.now().toString(36)}-${run.events.length}`,
+        createdAt: Date.now(),
+        label: trimmed,
+        state,
+      },
+    ].slice(-MAX_EVENTS);
+  }
+
+  private defaultSteps(): readonly CodexLiveTimelineStep[] {
+    return [
+      {
+        id: 'repo',
+        label: 'Analyse du repo',
+        detail: 'Lecture du contexte et des contraintes.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        id: 'files',
+        label: 'Identification des fichiers concernes',
+        detail: 'Selection des surfaces a modifier.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        id: 'tests',
+        label: 'Generation des tests',
+        detail: 'Preparation des verifications utiles.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        id: 'changes',
+        label: 'Application des changements',
+        detail: 'Patch cible et controle de coherence.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        id: 'ci',
+        label: 'Execution CI',
+        detail: 'Suivi du workflow et des preuves.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        id: 'commit',
+        label: 'Commit ou artefacts generes',
+        detail: 'Sortie du workflow de contribution.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+      {
+        id: 'pr',
+        label: 'Pull Request / preuve publiee',
+        detail: 'Lien final pret a inspecter.',
+        state: 'pending',
+        startedAt: null,
+        completedAt: null,
+      },
+    ];
+  }
+
+  private providerLabel(provider: string): string {
+    return provider === 'codex' ? 'Codex' : provider;
+  }
+
+  private isTerminal(state: GithubActionNotificationState): boolean {
+    return state === 'completed' || state === 'failed';
+  }
+
+  private clearTimers(): void {
+    for (const timer of this.timers) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
+}

--- a/openg7-org/src/app/domains/account/pages/alerts.page.html
+++ b/openg7-org/src/app/domains/account/pages/alerts.page.html
@@ -156,7 +156,7 @@
                 type="button"
                 class="inline-flex items-center rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 disabled:opacity-50"
                 (click)="onToggleRead(entry)"
-                [disabled]="isPending(entry.id)"
+                [disabled]="isPending(entry)"
                 data-og7-id="alert-toggle-read"
               >
                 {{ (entry.isRead ? 'pages.alerts.actions.markUnread' :
@@ -165,8 +165,8 @@
               <button
                 type="button"
                 class="inline-flex items-center rounded-lg border border-rose-200 bg-rose-50 px-3 py-1.5 text-xs font-semibold text-rose-700 transition hover:bg-rose-100 disabled:opacity-50"
-                (click)="onDelete(entry.id)"
-                [disabled]="isPending(entry.id)"
+                (click)="onDelete(entry)"
+                [disabled]="isPending(entry)"
                 data-og7-id="alert-delete"
               >
                 {{ 'pages.alerts.actions.delete' | translate }}

--- a/openg7-org/src/app/domains/account/pages/alerts.page.spec.ts
+++ b/openg7-org/src/app/domains/account/pages/alerts.page.spec.ts
@@ -9,6 +9,7 @@ import {
   OpportunityOfferRecord,
   OpportunityOffersService,
 } from '@app/core/opportunity-offers.service';
+import { NotificationEntry, NotificationStore } from '@app/core/observability/notification.store';
 import { UserAlertRecord } from '@app/core/services/user-alerts-api.service';
 import { UserAlertsService } from '@app/core/user-alerts.service';
 import { TranslateModule } from '@ngx-translate/core';
@@ -36,6 +37,18 @@ class UserAlertsServiceMock {
   readonly remove = jasmine.createSpy('remove');
 
   setEntries(entries: UserAlertRecord[]): void {
+    this.entriesSig.set(entries);
+  }
+}
+
+class NotificationStoreMock {
+  private readonly entriesSig = signal<NotificationEntry[]>([]);
+  readonly entries = this.entriesSig.asReadonly();
+  readonly markAllRead = jasmine.createSpy('markAllRead');
+  readonly updateEntry = jasmine.createSpy('updateEntry');
+  readonly dismiss = jasmine.createSpy('dismiss');
+
+  setEntries(entries: NotificationEntry[]): void {
     this.entriesSig.set(entries);
   }
 }
@@ -73,6 +86,7 @@ class OpportunityOffersServiceMock {
 
 describe('AlertsPage', () => {
   let alerts: UserAlertsServiceMock;
+  let notifications: NotificationStoreMock;
   let indicatorRules: IndicatorAlertRulesServiceMock;
   let opportunityOffers: OpportunityOffersServiceMock;
   let router: jasmine.SpyObj<Router>;
@@ -80,6 +94,7 @@ describe('AlertsPage', () => {
 
   beforeEach(async () => {
     alerts = new UserAlertsServiceMock();
+    notifications = new NotificationStoreMock();
     indicatorRules = new IndicatorAlertRulesServiceMock();
     opportunityOffers = new OpportunityOffersServiceMock();
     router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl', 'navigate']);
@@ -98,6 +113,21 @@ describe('AlertsPage', () => {
         readAt: null,
         createdAt: '2026-02-01T10:00:00.000Z',
         updatedAt: '2026-02-01T10:00:00.000Z',
+      },
+    ]);
+
+    notifications.setEntries([
+      {
+        id: 'agent-notification-1',
+        type: 'info',
+        title: 'Proposition agent',
+        message: 'Construire la surface pour cartes et geopatial.',
+        source: 'admin-quality-agent',
+        context: null,
+        metadata: null,
+        actions: [],
+        createdAt: new Date('2026-02-01T10:20:00.000Z').getTime(),
+        read: false,
       },
     ]);
 
@@ -177,10 +207,54 @@ describe('AlertsPage', () => {
           } as Pick<ActivatedRoute, 'queryParamMap' | 'snapshot'>,
         },
         { provide: UserAlertsService, useValue: alerts },
+        { provide: NotificationStore, useValue: notifications },
         { provide: IndicatorAlertRulesService, useValue: indicatorRules },
         { provide: OpportunityOffersService, useValue: opportunityOffers },
       ],
     }).compileComponents();
+  });
+
+  it('renders local notification messages in the alerts inbox', () => {
+    const fixture = TestBed.createComponent(AlertsPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const items = root.querySelectorAll('[data-og7="user-alert-item"]');
+
+    expect(items.length).toBe(2);
+    expect(root.textContent).toContain('Proposition agent');
+    expect(root.textContent).toContain('Construire la surface pour cartes et geopatial.');
+    expect(root.querySelectorAll('[data-og7-state="unread"]').length).toBe(2);
+  });
+
+  it('uses the local notification store actions for local inbox entries', () => {
+    const fixture = TestBed.createComponent(AlertsPage);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const agentItem = Array.from(root.querySelectorAll('[data-og7="user-alert-item"]')).find(
+      (item) => item.textContent?.includes('Proposition agent'),
+    ) as HTMLElement | undefined;
+    expect(agentItem).toBeDefined();
+
+    const toggleRead = agentItem?.querySelector(
+      '[data-og7-id="alert-toggle-read"]',
+    ) as HTMLButtonElement;
+    toggleRead.click();
+    fixture.detectChanges();
+
+    expect(notifications.updateEntry).toHaveBeenCalledWith('agent-notification-1', {
+      read: true,
+    });
+
+    const deleteButton = agentItem?.querySelector(
+      '[data-og7-id="alert-delete"]',
+    ) as HTMLButtonElement;
+    deleteButton.click();
+    fixture.detectChanges();
+
+    expect(notifications.dismiss).toHaveBeenCalledWith('agent-notification-1');
+    expect(alerts.remove).not.toHaveBeenCalledWith('agent-notification-1');
   });
 
   it('renders the indicator alert rules section', () => {

--- a/openg7-org/src/app/domains/account/pages/alerts.page.ts
+++ b/openg7-org/src/app/domains/account/pages/alerts.page.ts
@@ -11,10 +11,29 @@ import {
   OpportunityOfferRecord,
   OpportunityOffersService,
 } from '@app/core/opportunity-offers.service';
+import {
+  NotificationEntry,
+  injectNotificationStore,
+} from '@app/core/observability/notification.store';
 import { UserAlertRecord } from '@app/core/services/user-alerts-api.service';
 import { UserAlertsService } from '@app/core/user-alerts.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { map } from 'rxjs/operators';
+
+type AlertsInboxEntrySeverity = UserAlertRecord['severity'];
+type AlertsInboxEntryChannel = 'user-alert' | 'local-notification';
+
+interface AlertsInboxEntry {
+  readonly id: string;
+  readonly channel: AlertsInboxEntryChannel;
+  readonly title: string;
+  readonly message: string;
+  readonly severity: AlertsInboxEntrySeverity;
+  readonly sourceType: string | null;
+  readonly source: string | null;
+  readonly isRead: boolean;
+  readonly createdAt: string | number | null;
+}
 
 @Component({
   standalone: true,
@@ -32,6 +51,7 @@ export class AlertsPage {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly alerts = inject(UserAlertsService);
+  private readonly notifications = injectNotificationStore();
   private readonly indicatorAlertRules = inject(IndicatorAlertRulesService);
   private readonly opportunityOffers = inject(OpportunityOffersService);
   private readonly translate = inject(TranslateService);
@@ -41,9 +61,16 @@ export class AlertsPage {
   protected readonly markAllReadPending = this.alerts.markAllReadPending;
   protected readonly clearReadPending = this.alerts.clearReadPending;
   protected readonly error = this.alerts.error;
-  protected readonly entries = this.alerts.entries;
-  protected readonly hasEntries = this.alerts.hasEntries;
-  protected readonly unreadCount = this.alerts.unreadCount;
+  protected readonly entries = computed<readonly AlertsInboxEntry[]>(() =>
+    this.sortEntries([
+      ...this.alerts.entries().map((entry) => this.mapUserAlert(entry)),
+      ...this.notifications.entries().map((entry) => this.mapLocalNotification(entry)),
+    ]),
+  );
+  protected readonly hasEntries = computed(() => this.entries().length > 0);
+  protected readonly unreadCount = computed(
+    () => this.entries().filter((entry) => !entry.isRead).length,
+  );
   protected readonly indicatorRuleEntries = this.indicatorAlertRules.entries;
   protected readonly hasIndicatorRuleEntries = this.indicatorAlertRules.hasEntries;
   protected readonly opportunityOfferEntries = this.opportunityOffers.entries;
@@ -78,18 +105,33 @@ export class AlertsPage {
 
   protected onMarkAllRead(): void {
     this.alerts.markAllRead();
+    this.notifications.markAllRead();
   }
 
   protected onClearRead(): void {
     this.alerts.clearRead();
+    this.notifications
+      .entries()
+      .filter((entry) => entry.read)
+      .forEach((entry) => this.notifications.dismiss(entry.id));
   }
 
-  protected onToggleRead(entry: UserAlertRecord): void {
+  protected onToggleRead(entry: AlertsInboxEntry): void {
+    if (entry.channel === 'local-notification') {
+      this.notifications.updateEntry(entry.id, { read: !entry.isRead });
+      return;
+    }
+
     this.alerts.markRead(entry.id, !entry.isRead);
   }
 
-  protected onDelete(id: string): void {
-    this.alerts.remove(id);
+  protected onDelete(entry: AlertsInboxEntry): void {
+    if (entry.channel === 'local-notification') {
+      this.notifications.dismiss(entry.id);
+      return;
+    }
+
+    this.alerts.remove(entry.id);
   }
 
   protected onToggleIndicatorRule(entry: IndicatorAlertRuleRecord): void {
@@ -148,15 +190,15 @@ export class AlertsPage {
     return this.highlightedOpportunityOfferId() === id;
   }
 
-  protected isPending(id: string): boolean {
-    return Boolean(this.pendingById()[id]);
+  protected isPending(entry: AlertsInboxEntry): boolean {
+    return entry.channel === 'user-alert' && Boolean(this.pendingById()[entry.id]);
   }
 
-  protected alertState(entry: UserAlertRecord): 'read' | 'unread' {
+  protected alertState(entry: AlertsInboxEntry): 'read' | 'unread' {
     return entry.isRead ? 'read' : 'unread';
   }
 
-  protected severityClasses(entry: UserAlertRecord): string {
+  protected severityClasses(entry: AlertsInboxEntry): string {
     switch (entry.severity) {
       case 'critical':
         return 'border-rose-200 bg-rose-50 text-rose-700';
@@ -169,7 +211,11 @@ export class AlertsPage {
     }
   }
 
-  protected sourceLabel(entry: UserAlertRecord): string {
+  protected sourceLabel(entry: AlertsInboxEntry): string {
+    if (entry.channel === 'local-notification') {
+      return entry.source?.trim() || 'pages.alerts.sources.system';
+    }
+
     if (entry.sourceType === 'saved-search') {
       return 'pages.alerts.sources.savedSearch';
     }
@@ -262,7 +308,68 @@ export class AlertsPage {
     return Number.isFinite(value) ? value : null;
   }
 
-  protected trackById = (_: number, entry: UserAlertRecord) => entry.id;
+  private mapUserAlert(entry: UserAlertRecord): AlertsInboxEntry {
+    return {
+      id: entry.id,
+      channel: 'user-alert',
+      title: entry.title,
+      message: entry.message,
+      severity: entry.severity,
+      sourceType: entry.sourceType,
+      source: null,
+      isRead: entry.isRead,
+      createdAt: entry.createdAt,
+    };
+  }
+
+  private mapLocalNotification(entry: NotificationEntry): AlertsInboxEntry {
+    return {
+      id: entry.id,
+      channel: 'local-notification',
+      title: entry.title || this.translate.instant(`notifications.types.${entry.type}`),
+      message: entry.message,
+      severity: this.localNotificationSeverity(entry),
+      sourceType: 'notification',
+      source: entry.source ?? null,
+      isRead: entry.read,
+      createdAt: entry.createdAt,
+    };
+  }
+
+  private localNotificationSeverity(entry: NotificationEntry): AlertsInboxEntrySeverity {
+    switch (entry.type) {
+      case 'error':
+        return 'critical';
+      case 'success':
+        return 'success';
+      default:
+        return 'info';
+    }
+  }
+
+  private sortEntries(entries: readonly AlertsInboxEntry[]): readonly AlertsInboxEntry[] {
+    return [...entries].sort((left, right) => {
+      const unreadOrder = Number(left.isRead) - Number(right.isRead);
+      if (unreadOrder !== 0) {
+        return unreadOrder;
+      }
+      return this.toTimestamp(right.createdAt) - this.toTimestamp(left.createdAt);
+    });
+  }
+
+  private toTimestamp(candidate: string | number | null): number {
+    if (typeof candidate === 'number') {
+      return Number.isFinite(candidate) ? candidate : 0;
+    }
+    if (!candidate) {
+      return 0;
+    }
+
+    const parsed = Date.parse(candidate);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  protected trackById = (_: number, entry: AlertsInboxEntry) => `${entry.channel}:${entry.id}`;
   protected trackIndicatorRuleById = (_: number, entry: IndicatorAlertRuleRecord) => entry.id;
   protected trackOpportunityOfferById = (_: number, entry: OpportunityOfferRecord) => entry.id;
   protected trackOpportunityOfferActivityById = (

--- a/openg7-org/src/app/domains/admin/data-access/admin-github-action-tracker.service.ts
+++ b/openg7-org/src/app/domains/admin/data-access/admin-github-action-tracker.service.ts
@@ -4,6 +4,7 @@ import {
   GithubActionNotificationStatus,
   githubActionStatusMetadata,
 } from '@app/core/observability/github-action-notification-status';
+import { CodexLiveTimelineService } from '@app/core/observability/codex-live-timeline.service';
 import { injectNotificationStore } from '@app/core/observability/notification.store';
 import { catchError, of, Subscription, switchMap, timer } from 'rxjs';
 
@@ -26,12 +27,14 @@ export interface AdminGithubActionTrackingContext extends AdminGithubActionDispa
   readonly source: string | null;
   readonly parentNotificationId: string;
   readonly actionId: string;
+  readonly timelineRunId?: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
 export class AdminGithubActionTrackerService {
   private readonly ops = inject(AdminOpsService);
   private readonly notifications = injectNotificationStore();
+  private readonly liveTimeline = inject(CodexLiveTimelineService);
   private readonly subscriptions = new Map<string, Subscription>();
 
   createDispatchCorrelation(actionId: string): AdminGithubActionDispatchCorrelation {
@@ -76,6 +79,7 @@ export class AdminGithubActionTrackerService {
     });
 
     if (notificationId) {
+      this.liveTimeline.recordGithubStatus(context.timelineRunId, initialStatus);
       this.pollGithubAction(notificationId, dispatch, context);
     }
 
@@ -99,6 +103,7 @@ export class AdminGithubActionTrackerService {
         attempts += 1;
         const status = this.resolveStatus(snapshot, dispatch, context, attempts);
         this.updateNotification(notificationId, status, context, dispatch);
+        this.updateLiveTimeline(snapshot, status, context, dispatch);
 
         if (this.isTerminal(status.state) || attempts >= GITHUB_ACTION_MAX_POLLS) {
           if (attempts >= GITHUB_ACTION_MAX_POLLS && !this.isTerminal(status.state)) {
@@ -128,7 +133,9 @@ export class AdminGithubActionTrackerService {
     context: AdminGithubActionTrackingContext,
     attempts: number,
   ): GithubActionNotificationStatus {
-    const proof = snapshot?.providers.find((provider) => provider.provider === dispatch.selectedProvider);
+    const proof = snapshot?.providers.find(
+      (provider) => provider.provider === dispatch.selectedProvider,
+    );
     const run = proof?.run ?? null;
     const requestedAtMs = Date.parse(dispatch.requestedAt);
     const runCreatedAtMs = Date.parse(run?.createdAt ?? '');
@@ -136,7 +143,8 @@ export class AdminGithubActionTrackerService {
       Boolean(run) &&
       run?.correlationId === context.correlationId &&
       (!Number.isFinite(requestedAtMs) ||
-        (Number.isFinite(runCreatedAtMs) && runCreatedAtMs >= requestedAtMs - TRACKED_RUN_GRACE_MS));
+        (Number.isFinite(runCreatedAtMs) &&
+          runCreatedAtMs >= requestedAtMs - TRACKED_RUN_GRACE_MS));
 
     if (!snapshot) {
       return this.buildStatus({
@@ -190,6 +198,26 @@ export class AdminGithubActionTrackerService {
       },
       read: false,
     });
+  }
+
+  private updateLiveTimeline(
+    snapshot: AdminOpsAiProofSnapshot | null,
+    status: GithubActionNotificationStatus,
+    context: AdminGithubActionTrackingContext,
+    dispatch: AdminOpsCodexDispatchResponse,
+  ): void {
+    this.liveTimeline.recordGithubStatus(context.timelineRunId, status);
+
+    const proof = snapshot?.providers.find(
+      (provider) => provider.provider === dispatch.selectedProvider,
+    );
+    if (proof?.pullRequest) {
+      this.liveTimeline.recordPullRequest(context.timelineRunId, {
+        number: proof.pullRequest.number,
+        url: proof.pullRequest.url,
+        title: proof.pullRequest.title,
+      });
+    }
   }
 
   private buildStatus(input: {
@@ -247,6 +275,10 @@ export class AdminGithubActionTrackerService {
   }
 
   private sanitizeToken(value: string): string {
-    return value.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '');
   }
 }

--- a/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.html
+++ b/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.html
@@ -1,0 +1,111 @@
+@if (isOpen()) {
+  @if (run(); as activeRun) {
+    <aside
+      class="codex-live-timeline"
+      data-og7="codex-live-timeline"
+      role="status"
+      aria-live="polite"
+      aria-relevant="additions text"
+    >
+      <header class="codex-live-timeline__header">
+        <div class="codex-live-timeline__heading">
+          <span class="codex-live-timeline__pulse" aria-hidden="true"></span>
+          <div>
+            <p class="codex-live-timeline__eyebrow">
+              {{ 'codexLiveTimeline.eyebrow' | translate }}
+            </p>
+            <h2 class="codex-live-timeline__title">{{ activeRun.title }}</h2>
+            <p class="codex-live-timeline__subtitle">{{ activeRun.subtitle }}</p>
+          </div>
+        </div>
+
+        <div class="codex-live-timeline__actions">
+          <button
+            type="button"
+            class="codex-live-timeline__icon-button"
+            (click)="hide()"
+            [attr.aria-label]="'codexLiveTimeline.hide' | translate"
+          >
+            <span aria-hidden="true"></span>
+          </button>
+          <button
+            type="button"
+            class="codex-live-timeline__icon-button codex-live-timeline__icon-button--close"
+            (click)="clear()"
+            [attr.aria-label]="'codexLiveTimeline.close' | translate"
+          >
+            <span aria-hidden="true"></span>
+          </button>
+        </div>
+      </header>
+
+      <div class="codex-live-timeline__meta">
+        <span>{{ activeRun.provider }}</span>
+        @if (activeRun.workflow) {
+          <span>{{ activeRun.workflow }}</span>
+        }
+        @if (activeRun.ref) {
+          <span>{{ activeRun.ref }}</span>
+        }
+        @if (activeRun.runNumber) {
+          <span>#{{ activeRun.runNumber }}</span>
+        }
+      </div>
+
+      <ol class="codex-live-timeline__steps">
+        <li
+          *ngFor="let step of activeRun.steps; trackBy: trackStep"
+          class="codex-live-timeline__step"
+          [attr.data-state]="step.state"
+        >
+          <span class="codex-live-timeline__marker" aria-hidden="true"></span>
+          <div class="codex-live-timeline__step-body">
+            <div class="codex-live-timeline__step-row">
+              <span class="codex-live-timeline__step-label">{{ step.label }}</span>
+              @if (step.startedAt) {
+                <time class="codex-live-timeline__step-time">
+                  {{ step.startedAt | date: 'HH:mm:ss' }}
+                </time>
+              }
+            </div>
+            <p class="codex-live-timeline__step-detail">{{ step.detail }}</p>
+          </div>
+        </li>
+      </ol>
+
+      <section class="codex-live-timeline__stream" data-og7="codex-live-timeline-stream">
+        <div class="codex-live-timeline__stream-header">
+          <span>{{ 'codexLiveTimeline.streamTitle' | translate }}</span>
+          @if (!activeRun.terminalState) {
+            <span class="codex-live-timeline__typing" aria-hidden="true"></span>
+          }
+        </div>
+        <ol class="codex-live-timeline__events">
+          <li
+            *ngFor="let event of activeRun.events; trackBy: trackEvent"
+            class="codex-live-timeline__event"
+            [attr.data-state]="event.state"
+          >
+            <time>[{{ event.createdAt | date: 'HH:mm:ss' }}]</time>
+            <span>{{ event.label }}</span>
+          </li>
+        </ol>
+      </section>
+
+      @if (activeRun.runUrl || activeRun.pullRequestUrl) {
+        <footer class="codex-live-timeline__footer">
+          @if (activeRun.runUrl) {
+            <a [href]="activeRun.runUrl" target="_blank" rel="noopener">
+              {{ 'codexLiveTimeline.openRun' | translate }}
+            </a>
+          }
+          @if (activeRun.pullRequestUrl) {
+            <a [href]="activeRun.pullRequestUrl" target="_blank" rel="noopener">
+              {{ 'codexLiveTimeline.openPullRequest' | translate }}
+            </a>
+          }
+        </footer>
+      }
+    </aside>
+  }
+}

--- a/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.scss
+++ b/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.scss
@@ -1,0 +1,413 @@
+.codex-live-timeline {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 95;
+  width: min(27rem, calc(100vw - 2rem));
+  max-height: min(44rem, calc(100vh - 2rem));
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  overflow: hidden;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  border-radius: 1rem;
+  background:
+    linear-gradient(150deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.94)),
+    radial-gradient(circle at 12% 10%, rgba(34, 211, 238, 0.18), transparent 34%);
+  box-shadow: 0 24px 70px rgba(2, 6, 23, 0.42);
+  color: #e2e8f0;
+  padding: 1rem;
+  backdrop-filter: blur(22px);
+}
+
+.codex-live-timeline__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.codex-live-timeline__heading {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+}
+
+.codex-live-timeline__pulse {
+  flex: 0 0 auto;
+  width: 0.85rem;
+  height: 0.85rem;
+  margin-top: 0.25rem;
+  border-radius: 9999px;
+  background: #22d3ee;
+  box-shadow:
+    0 0 0 0 rgba(34, 211, 238, 0.42),
+    0 0 1rem rgba(34, 211, 238, 0.52);
+  animation: og7CodexLivePulse 1.3s ease-in-out infinite;
+}
+
+.codex-live-timeline__eyebrow {
+  margin: 0;
+  color: rgba(165, 243, 252, 0.9);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.codex-live-timeline__title {
+  margin: 0.16rem 0 0;
+  color: #f8fafc;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.codex-live-timeline__subtitle {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin: 0.22rem 0 0;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.codex-live-timeline__actions {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.codex-live-timeline__icon-button {
+  width: 2rem;
+  height: 2rem;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 0.7rem;
+  background: rgba(15, 23, 42, 0.35);
+  color: #e2e8f0;
+  cursor: pointer;
+}
+
+.codex-live-timeline__icon-button:hover,
+.codex-live-timeline__icon-button:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.codex-live-timeline__icon-button span {
+  width: 0.8rem;
+  height: 0.12rem;
+  border-radius: 9999px;
+  background: currentColor;
+}
+
+.codex-live-timeline__icon-button--close span {
+  position: relative;
+  transform: rotate(45deg);
+}
+
+.codex-live-timeline__icon-button--close span::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: currentColor;
+  transform: rotate(90deg);
+}
+
+.codex-live-timeline__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.codex-live-timeline__meta span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.34);
+  padding: 0.25rem 0.52rem;
+  color: rgba(248, 250, 252, 0.88);
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.codex-live-timeline__steps,
+.codex-live-timeline__events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.codex-live-timeline__steps {
+  display: grid;
+  gap: 0.45rem;
+  overflow-y: auto;
+  padding-right: 0.2rem;
+  scrollbar-color: rgba(148, 163, 184, 0.9) rgba(15, 23, 42, 0.34);
+  scrollbar-width: thin;
+}
+
+.codex-live-timeline__step {
+  display: grid;
+  grid-template-columns: 1.35rem minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: flex-start;
+}
+
+.codex-live-timeline__marker {
+  position: relative;
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.13rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.82);
+}
+
+.codex-live-timeline__step:not(:last-child) .codex-live-timeline__marker::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 1.1rem;
+  width: 1px;
+  height: 1.65rem;
+  background: rgba(148, 163, 184, 0.24);
+  transform: translateX(-50%);
+}
+
+.codex-live-timeline__step[data-state='active'] .codex-live-timeline__marker {
+  border-color: rgba(34, 211, 238, 0.85);
+  box-shadow: 0 0 0 0.25rem rgba(34, 211, 238, 0.12);
+}
+
+.codex-live-timeline__step[data-state='active'] .codex-live-timeline__marker::after {
+  content: '';
+  position: absolute;
+  inset: 0.22rem;
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  border-top-color: #67e8f9;
+  animation: og7CodexLiveSpin 0.9s linear infinite;
+}
+
+.codex-live-timeline__step[data-state='completed'] .codex-live-timeline__marker {
+  border-color: rgba(52, 211, 153, 0.9);
+  background: #34d399;
+}
+
+.codex-live-timeline__step[data-state='completed'] .codex-live-timeline__marker::after {
+  content: '';
+  position: absolute;
+  left: 0.34rem;
+  top: 0.22rem;
+  width: 0.32rem;
+  height: 0.56rem;
+  border: solid #052e2b;
+  border-width: 0 0.13rem 0.13rem 0;
+  transform: rotate(45deg);
+}
+
+.codex-live-timeline__step[data-state='failed'] .codex-live-timeline__marker {
+  border-color: rgba(251, 113, 133, 0.9);
+  background: #fb7185;
+}
+
+.codex-live-timeline__step[data-state='failed'] .codex-live-timeline__marker::after {
+  content: '';
+  position: absolute;
+  inset: 0.45rem 0.24rem;
+  border-radius: 9999px;
+  background: #450a0a;
+  transform: rotate(45deg);
+}
+
+.codex-live-timeline__step[data-state='failed'] .codex-live-timeline__marker::before {
+  background: rgba(251, 113, 133, 0.4);
+}
+
+.codex-live-timeline__step-body {
+  min-width: 0;
+}
+
+.codex-live-timeline__step-row {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.codex-live-timeline__step-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #f8fafc;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.codex-live-timeline__step[data-state='pending'] .codex-live-timeline__step-label {
+  color: rgba(226, 232, 240, 0.58);
+}
+
+.codex-live-timeline__step-time {
+  flex: 0 0 auto;
+  color: rgba(186, 230, 253, 0.8);
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.codex-live-timeline__step-detail {
+  margin: 0.12rem 0 0;
+  color: rgba(203, 213, 225, 0.68);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.codex-live-timeline__stream {
+  min-height: 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding-top: 0.8rem;
+}
+
+.codex-live-timeline__stream-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.codex-live-timeline__typing {
+  width: 2.1rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, #67e8f9 40%, transparent 42%) 0 50% / 0.7rem 0.45rem,
+    radial-gradient(circle, #67e8f9 40%, transparent 42%) 0.7rem 50% / 0.7rem 0.45rem,
+    radial-gradient(circle, #67e8f9 40%, transparent 42%) 1.4rem 50% / 0.7rem 0.45rem;
+  opacity: 0.72;
+  animation: og7CodexLiveTyping 1.2s ease-in-out infinite;
+}
+
+.codex-live-timeline__events {
+  max-height: 9.5rem;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.38rem;
+  margin-top: 0.55rem;
+  padding-right: 0.2rem;
+  scrollbar-color: rgba(148, 163, 184, 0.9) rgba(15, 23, 42, 0.34);
+  scrollbar-width: thin;
+}
+
+.codex-live-timeline__event {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.45rem;
+  align-items: baseline;
+  color: rgba(226, 232, 240, 0.82);
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
+.codex-live-timeline__event[data-state='completed'] {
+  color: rgba(187, 247, 208, 0.9);
+}
+
+.codex-live-timeline__event[data-state='failed'] {
+  color: rgba(254, 202, 202, 0.94);
+}
+
+.codex-live-timeline__event time {
+  color: rgba(125, 211, 252, 0.78);
+  font-variant-numeric: tabular-nums;
+}
+
+.codex-live-timeline__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding-top: 0.85rem;
+}
+
+.codex-live-timeline__footer a {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  border-radius: 0.7rem;
+  background: rgba(14, 165, 233, 0.14);
+  padding: 0.35rem 0.65rem;
+  color: #e0f2fe;
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.codex-live-timeline__footer a:hover,
+.codex-live-timeline__footer a:focus-visible {
+  background: rgba(14, 165, 233, 0.22);
+}
+
+@keyframes og7CodexLivePulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(34, 211, 238, 0.34),
+      0 0 1rem rgba(34, 211, 238, 0.52);
+    transform: scale(0.94);
+  }
+
+  50% {
+    box-shadow:
+      0 0 0 0.45rem rgba(34, 211, 238, 0),
+      0 0 1.2rem rgba(34, 211, 238, 0.64);
+    transform: scale(1.08);
+  }
+}
+
+@keyframes og7CodexLiveSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes og7CodexLiveTyping {
+  0%,
+  100% {
+    opacity: 0.38;
+  }
+
+  50% {
+    opacity: 0.96;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .codex-live-timeline__pulse,
+  .codex-live-timeline__typing,
+  .codex-live-timeline__step[data-state='active'] .codex-live-timeline__marker::after {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .codex-live-timeline {
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: min(100vw - 1.5rem, 27rem);
+    max-height: min(42rem, calc(100vh - 1.5rem));
+  }
+}

--- a/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.spec.ts
+++ b/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { CodexLiveTimelineService } from '@app/core/observability/codex-live-timeline.service';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { CodexLiveTimelineComponent } from './codex-live-timeline.component';
+
+describe('CodexLiveTimelineComponent', () => {
+  let timeline: CodexLiveTimelineService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CodexLiveTimelineComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+
+    timeline = TestBed.inject(CodexLiveTimelineService);
+  });
+
+  afterEach(() => {
+    timeline.clear();
+  });
+
+  it('opens a live timeline and streams progressive steps', fakeAsync(() => {
+    timeline.start({
+      provider: 'codex',
+      task: 'Construire la surface admin-quality.',
+      source: 'admin-quality-agent',
+      actionLabel: 'Codex Preuve',
+    });
+
+    const fixture = TestBed.createComponent(CodexLiveTimelineComponent);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelector('[data-og7="codex-live-timeline"]')).not.toBeNull();
+    expect(root.textContent).toContain('Deploiement du chantier');
+    expect(root.textContent).toContain('Analyse du repo');
+
+    tick(950);
+    fixture.detectChanges();
+
+    expect(root.textContent).toContain('Identification des fichiers concernes');
+    expect(root.textContent).toContain('[');
+    timeline.clear();
+  }));
+
+  it('renders GitHub workflow and pull request links when available', () => {
+    const runId = timeline.start({
+      provider: 'codex',
+      task: 'Construire la surface admin-quality.',
+    });
+    timeline.recordDispatchQueued(runId, { workflow: 'codex-pr.yml', ref: 'main' });
+    timeline.recordGithubStatus(runId, {
+      state: 'completed',
+      label: 'GitHub Actions - termine',
+      detail: 'Workflow termine.',
+      workflow: 'codex-pr.yml',
+      runUrl: 'https://github.test/actions/runs/42',
+      runNumber: 42,
+      correlationId: 'og7-test-correlation',
+      updatedAt: '2026-05-15T00:00:00.000Z',
+    });
+    timeline.recordPullRequest(runId, {
+      number: 482,
+      url: 'https://github.test/pulls/482',
+      title: 'Codex proof',
+    });
+
+    const fixture = TestBed.createComponent(CodexLiveTimelineComponent);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.textContent).toContain('codex-pr.yml');
+    expect(root.textContent).toContain('#42');
+    expect(root.textContent).toContain('Pull Request ouverte #482.');
+    expect(root.querySelector('a[href="https://github.test/actions/runs/42"]')).not.toBeNull();
+    expect(root.querySelector('a[href="https://github.test/pulls/482"]')).not.toBeNull();
+  });
+});

--- a/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.ts
+++ b/openg7-org/src/app/shared/components/layout/codex-live-timeline/codex-live-timeline.component.ts
@@ -1,0 +1,34 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  CodexLiveTimelineEvent,
+  CodexLiveTimelineService,
+  CodexLiveTimelineStep,
+} from '@app/core/observability/codex-live-timeline.service';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'og7-codex-live-timeline',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  templateUrl: './codex-live-timeline.component.html',
+  styleUrl: './codex-live-timeline.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CodexLiveTimelineComponent {
+  private readonly timeline = inject(CodexLiveTimelineService);
+
+  readonly run = this.timeline.run;
+  readonly isOpen = this.timeline.isOpen;
+
+  hide(): void {
+    this.timeline.hide();
+  }
+
+  clear(): void {
+    this.timeline.clear();
+  }
+
+  trackStep = (_: number, step: CodexLiveTimelineStep) => step.id;
+  trackEvent = (_: number, event: CodexLiveTimelineEvent) => event.id;
+}

--- a/openg7-org/src/app/shared/components/layout/notification-toast-tray/notification-toast-tray.component.spec.ts
+++ b/openg7-org/src/app/shared/components/layout/notification-toast-tray/notification-toast-tray.component.spec.ts
@@ -241,13 +241,14 @@ describe('NotificationToastTrayComponent', () => {
     );
     expect(tracker.startTracking).toHaveBeenCalledWith(
       jasmine.objectContaining({ workflow: 'codex.yml', ref: 'main' }),
-      {
+      jasmine.objectContaining({
         source: 'admin-quality-agent',
         parentNotificationId: 'toast-1',
         actionId: 'dispatch-codex',
         correlationId: 'og7-test-correlation',
         idempotencyKey: 'og7-test-correlation-dispatch-codex',
-      },
+        timelineRunId: jasmine.any(String),
+      }),
     );
     expect(notifications.markAsRead).toHaveBeenCalledWith('toast-1');
     expect(fixture.debugElement.query(By.css('[data-og7="notification-toast"]'))).toBeNull();

--- a/openg7-org/src/app/shared/components/layout/notification-toast-tray/notification-toast-tray.component.ts
+++ b/openg7-org/src/app/shared/components/layout/notification-toast-tray/notification-toast-tray.component.ts
@@ -15,6 +15,7 @@ import {
   GithubActionNotificationStatus,
   readGithubActionNotificationStatus,
 } from '@app/core/observability/github-action-notification-status';
+import { CodexLiveTimelineService } from '@app/core/observability/codex-live-timeline.service';
 import {
   NotificationEntry,
   NotificationAction,
@@ -50,6 +51,7 @@ export class NotificationToastTrayComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly injector = inject(Injector);
   private readonly router = inject(Router);
+  private readonly liveTimeline = inject(CodexLiveTimelineService);
   private readonly dismissTimers = new Map<string, DismissTimerState>();
   private readonly hiddenToastIds = signal<ReadonlySet<string>>(new Set());
   private adminOpsService: AdminOpsService | null | undefined;
@@ -208,12 +210,23 @@ export class NotificationToastTrayComponent {
       return;
     }
 
+    const timelineRunId = this.liveTimeline.start({
+      provider: codexDispatch.provider,
+      task: codexDispatch.task,
+      source: entry.source ?? 'notification-toast',
+      actionLabel: action.label,
+    });
+
     const adminOps = this.resolveAdminOpsService();
     if (!adminOps) {
       this.notificationsStore.error('Console Ops indisponible pour lancer Codex.', {
         source: entry.source ?? 'notification-toast',
         metadata: { parentNotificationId: entry.id, actionId: action.id },
       });
+      this.liveTimeline.recordDispatchError(
+        timelineRunId,
+        'Console Ops indisponible pour lancer Codex.',
+      );
       return;
     }
 
@@ -230,11 +243,16 @@ export class NotificationToastTrayComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (result) => {
+          this.liveTimeline.recordDispatchQueued(timelineRunId, {
+            workflow: result.workflow,
+            ref: result.ref,
+          });
           if (tracker && correlation) {
             tracker.startTracking(result, {
               source: entry.source ?? 'notification-toast',
               parentNotificationId: entry.id,
               actionId: action.id,
+              timelineRunId,
               ...correlation,
             });
           } else {
@@ -250,15 +268,27 @@ export class NotificationToastTrayComponent {
                 },
               },
             );
+            this.liveTimeline.recordGithubStatus(timelineRunId, {
+              state: 'queued',
+              label: 'GitHub Actions - en file',
+              detail: `${this.providerLabel(codexDispatch.provider)} queued via ${result.workflow} on ${result.ref}.`,
+              workflow: result.workflow,
+              runUrl: null,
+              runNumber: null,
+              correlationId: correlation?.correlationId ?? null,
+              updatedAt: new Date().toISOString(),
+            });
           }
           this.notificationsStore.markAsRead(entry.id);
           this.hideToast(entry.id);
         },
         error: (error: unknown) => {
-          this.notificationsStore.error(this.resolveDispatchError(error, codexDispatch.provider), {
+          const message = this.resolveDispatchError(error, codexDispatch.provider);
+          this.notificationsStore.error(message, {
             source: entry.source ?? 'notification-toast',
             metadata: { parentNotificationId: entry.id, actionId: action.id },
           });
+          this.liveTimeline.recordDispatchError(timelineRunId, message);
         },
       });
   }

--- a/openg7-org/src/app/shared/components/layout/site-header/site-header.component.html
+++ b/openg7-org/src/app/shared/components/layout/site-header/site-header.component.html
@@ -440,7 +440,7 @@
       </button>
       <div
         *ngIf="isNotifOpen()"
-        class="w-full rounded-xl border border-white/15 bg-slate-900/90 p-3 text-sm text-white/80"
+        class="site-header__notifications-panel site-header__notifications-panel--mobile flex w-full flex-col rounded-xl border border-white/15 bg-slate-900/90 p-3 text-sm text-white/80"
         data-og7="notif"
         data-og7-id="header-mobile-alerts-panel"
       >
@@ -450,7 +450,10 @@
         <p *ngIf="!notificationEntries().length" class="text-sm text-white/60">
           {{ 'header.notifications.empty' | translate }}
         </p>
-        <ul *ngIf="notificationEntries().length" class="space-y-1 text-sm text-white/80">
+        <ul
+          *ngIf="notificationEntries().length"
+          class="site-header__notifications-list space-y-1 text-sm text-white/80"
+        >
           <li
             *ngFor="let notification of notificationEntries(); trackBy: trackNotification"
             class="rounded-lg bg-white/5 p-2"
@@ -597,7 +600,7 @@
 
   <div
     *ngIf="isNotifOpen()"
-    class="absolute right-4 top-16 hidden w-80 overflow-hidden rounded-xl border border-white/10 bg-slate-800/95 p-3 shadow-2xl backdrop-blur sm:block"
+    class="site-header__notifications-panel absolute right-4 top-16 hidden w-80 rounded-xl border border-white/10 bg-slate-800/95 p-3 shadow-2xl backdrop-blur sm:flex sm:flex-col"
     data-og7="notif"
     data-og7-id="header-alerts-panel"
   >
@@ -607,7 +610,10 @@
     <p *ngIf="!notificationEntries().length" class="text-sm text-white/60">
       {{ 'header.notifications.empty' | translate }}
     </p>
-    <ul *ngIf="notificationEntries().length" class="space-y-1 text-sm text-white/80">
+    <ul
+      *ngIf="notificationEntries().length"
+      class="site-header__notifications-list space-y-1 text-sm text-white/80"
+    >
       <li
         *ngFor="let notification of notificationEntries(); trackBy: trackNotification"
         class="rounded-lg bg-white/5 p-2"

--- a/openg7-org/src/app/shared/components/layout/site-header/site-header.component.scss
+++ b/openg7-org/src/app/shared/components/layout/site-header/site-header.component.scss
@@ -116,6 +116,43 @@
   background-color: transparent;
 }
 
+:host .site-header__notifications-panel {
+  max-height: calc(100vh - 5rem);
+  overflow: hidden;
+}
+
+:host .site-header__notifications-panel--mobile {
+  max-height: min(32rem, calc(100vh - 10rem));
+}
+
+:host .site-header__notifications-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.25rem;
+  scrollbar-color: rgba(148, 163, 184, 0.95) rgba(15, 23, 42, 0.4);
+  scrollbar-width: thin;
+}
+
+:host .site-header__notifications-list::-webkit-scrollbar {
+  width: 0.45rem;
+}
+
+:host .site-header__notifications-list::-webkit-scrollbar-track {
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+:host .site-header__notifications-list::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.95);
+}
+
+:host .site-header__notifications-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(203, 213, 225, 0.95);
+}
+
 :host .site-header__github-status {
   display: inline-flex;
   align-items: center;

--- a/openg7-org/src/app/shared/components/layout/site-header/site-header.component.ts
+++ b/openg7-org/src/app/shared/components/layout/site-header/site-header.component.ts
@@ -22,6 +22,7 @@ import {
   GithubActionNotificationStatus,
   readGithubActionNotificationStatus,
 } from '@app/core/observability/github-action-notification-status';
+import { CodexLiveTimelineService } from '@app/core/observability/codex-live-timeline.service';
 import {
   NotificationAction,
   NotificationEntry,
@@ -79,6 +80,7 @@ export class SiteHeaderComponent {
   private readonly authConfig = inject(AuthConfigService);
   private readonly notifications = injectNotificationStore();
   private readonly router = inject(Router);
+  private readonly liveTimeline = inject(CodexLiveTimelineService);
   private readonly rbac = inject(RbacFacadeService);
   private readonly userAlerts = inject(UserAlertsService);
   private readonly quickSearchLauncher = inject(QuickSearchLauncherService);
@@ -354,12 +356,23 @@ export class SiteHeaderComponent {
       return;
     }
 
+    const timelineRunId = this.liveTimeline.start({
+      provider: codexDispatch.provider,
+      task: codexDispatch.task,
+      source: notification.source ?? 'site-header',
+      actionLabel: action.label,
+    });
+
     const adminOps = this.resolveAdminOpsService();
     if (!adminOps) {
       this.notifications.error('Console Ops indisponible pour lancer Codex.', {
         source: notification.source ?? 'site-header',
         metadata: { parentNotificationId: notification.id, actionId: action.id },
       });
+      this.liveTimeline.recordDispatchError(
+        timelineRunId,
+        'Console Ops indisponible pour lancer Codex.',
+      );
       return;
     }
 
@@ -376,11 +389,16 @@ export class SiteHeaderComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (result) => {
+          this.liveTimeline.recordDispatchQueued(timelineRunId, {
+            workflow: result.workflow,
+            ref: result.ref,
+          });
           if (tracker && correlation) {
             tracker.startTracking(result, {
               source: notification.source ?? 'site-header',
               parentNotificationId: notification.id,
               actionId: action.id,
+              timelineRunId,
               ...correlation,
             });
           } else {
@@ -396,15 +414,27 @@ export class SiteHeaderComponent {
                 },
               },
             );
+            this.liveTimeline.recordGithubStatus(timelineRunId, {
+              state: 'queued',
+              label: 'GitHub Actions - en file',
+              detail: `${this.providerLabel(codexDispatch.provider)} queued via ${result.workflow} on ${result.ref}.`,
+              workflow: result.workflow,
+              runUrl: null,
+              runNumber: null,
+              correlationId: correlation?.correlationId ?? null,
+              updatedAt: new Date().toISOString(),
+            });
           }
           this.notifications.markAsRead(notification.id);
           this.isNotifOpen.set(false);
         },
         error: (error: unknown) => {
-          this.notifications.error(this.resolveDispatchError(error, codexDispatch.provider), {
+          const message = this.resolveDispatchError(error, codexDispatch.provider);
+          this.notifications.error(message, {
             source: notification.source ?? 'site-header',
             metadata: { parentNotificationId: notification.id, actionId: action.id },
           });
+          this.liveTimeline.recordDispatchError(timelineRunId, message);
         },
       });
   }

--- a/openg7-org/src/assets/i18n/en.json
+++ b/openg7-org/src/assets/i18n/en.json
@@ -534,6 +534,14 @@
       "locked": "Boost visibility"
     }
   },
+  "codexLiveTimeline": {
+    "eyebrow": "Real-time timeline",
+    "streamTitle": "Live stream",
+    "hide": "Hide Codex timeline",
+    "close": "Close Codex timeline",
+    "openRun": "Open run",
+    "openPullRequest": "Open PR"
+  },
   "footer": {
     "links": {
       "ariaLabel": "Footer navigation",

--- a/openg7-org/src/assets/i18n/fr.json
+++ b/openg7-org/src/assets/i18n/fr.json
@@ -534,6 +534,14 @@
       "locked": "Booster ma visibilité"
     }
   },
+  "codexLiveTimeline": {
+    "eyebrow": "Timeline temps réel",
+    "streamTitle": "Flux live",
+    "hide": "Masquer la timeline Codex",
+    "close": "Fermer la timeline Codex",
+    "openRun": "Ouvrir le run",
+    "openPullRequest": "Ouvrir la PR"
+  },
   "footer": {
     "links": {
       "ariaLabel": "Navigation de pied de page",


### PR DESCRIPTION
- Implemented CodexLiveTimelineService to manage live timeline events and states.
- Created CodexLiveTimelineComponent for displaying the live timeline UI.
- Added styles for the live timeline component.
- Integrated notifications with the live timeline for GitHub Actions dispatches.
- Updated translations for new timeline features in English and French.
- Added unit tests for the CodexLiveTimelineComponent to ensure functionality.

## Summary

Describe the change (scope, motivation, user or technical impact).

## Details / decisions

- Design choices or tradeoffs
- Documentation or configuration impact

## Anti-duplication checklist

- [ ] I reviewed docs/ecosystem/ECOSYSTEM-MAP.md
- [ ] I confirmed whether this capability already has a canonical repo
- [ ] If reusable by 2+ repos, I proposed a shared @openg7/\* package instead of copy/paste
- [ ] I did not introduce canonical domain logic into openg7-nexus

## Tests

- [ ] `yarn lint`
- [ ] `yarn format:check`
- [ ] `yarn validate:selectors`
- [ ] `yarn codegen && yarn test`
- [ ] `yarn predeploy:cms-cache`
- [ ] `yarn prebuild:web`
- [ ] Other (specify):

## Review

- [ ] Docs updated (README, docs, or comments)
- [ ] Screenshot attached if UI
- [ ] Linked issue referenced
